### PR TITLE
`Change` journeys

### DIFF
--- a/tests/spec/README
+++ b/tests/spec/README
@@ -52,6 +52,6 @@ Upload - Automated
 1 - Component label
 2 - Component label and component label summary version
 3 - Component label and component label summary version and input name
-4 - Component label
-5 - Component label and component label summary version
-6 - Component label and component label summary version and input name
+4 - Component label, max files 3
+5 - Component label and component label summary version, max files 3
+6 - Component label and component label summary version and input name, max files 3

--- a/tests/spec/autocomplete_spec.rb
+++ b/tests/spec/autocomplete_spec.rb
@@ -58,6 +58,22 @@ describe 'Autocomplete' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Autocomplete - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'Four - summary version'
 
+    # Change
+    find('.govuk-summary-list:nth-of-type(4) .govuk-summary-list__actions a').click
+
+    # autocomplete
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Fourth - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Autocomplete - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - Fourth - hint text'
+
+    fill_in 'page_autocomplete-fourth--autocomplete_auto_name_4', with: "One\n" # the new line 'presses enter' on the selected option
+    continue
+
+    # summary
+    expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Autocomplete - Fourth - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Autocomplete - Fourth'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'One - summary version'
+
     click_on 'Accept and send application'
 
     # confirmation

--- a/tests/spec/checkboxes_spec.rb
+++ b/tests/spec/checkboxes_spec.rb
@@ -61,6 +61,24 @@ describe 'Checkboxes' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Checkboxes - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: /One - summary version\s*Two - summary version\s*Three - summary version\s*Four - summary version/
 
+    # Change
+    find('.govuk-summary-list:nth-of-type(4) .govuk-summary-list__actions a').click
+
+    # checkboxes
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Fourth - section heading'
+    expect(page).to have_selector 'h1', text: 'Checkboxes - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Fourth - hint text'
+
+    check 'checkboxes-one', visible: false
+    check 'checkboxes-two', visible: false
+    check 'checkboxes-three', visible: false
+    continue
+
+    # summary
+    expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Checkboxes - Fourth - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Checkboxes - Fourth'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'Four - summary version'
+
     click_on 'Accept and send application'
 
     # confirmation

--- a/tests/spec/date_spec.rb
+++ b/tests/spec/date_spec.rb
@@ -11,9 +11,9 @@ describe 'Date' do
     expect(page).to have_selector 'h1', text: 'Date - First'
     expect(page).to have_selector '.govuk-hint', text: 'Date - First - hint text'
 
-    fill_in 'COMPOSITE--auto_name_1-day', with: '1'
-    fill_in 'COMPOSITE--auto_name_1-month', with: '1'
-    fill_in 'COMPOSITE--auto_name_1-year', with: '1970'
+    fill_in 'COMPOSITE--auto_name_1-day', with: "1"
+    fill_in 'COMPOSITE--auto_name_1-month', with: "1"
+    fill_in 'COMPOSITE--auto_name_1-year', with: "1970"
 
     continue
 
@@ -22,9 +22,9 @@ describe 'Date' do
     expect(page).to have_selector 'h1', text: 'Date - Second'
     expect(page).to have_selector '.govuk-hint', text: 'Date - Second - hint text'
 
-    fill_in 'COMPOSITE--auto_name_2-day', with: '2'
-    fill_in 'COMPOSITE--auto_name_2-month', with: '2'
-    fill_in 'COMPOSITE--auto_name_2-year', with: '1971'
+    fill_in 'COMPOSITE--auto_name_2-day', with: "2"
+    fill_in 'COMPOSITE--auto_name_2-month', with: "2"
+    fill_in 'COMPOSITE--auto_name_2-year', with: "1971"
     continue
 
     # date
@@ -32,19 +32,19 @@ describe 'Date' do
     expect(page).to have_selector 'h1', text: 'Date - Third'
     expect(page).to have_selector '.govuk-hint', text: 'Date - Third - hint text'
 
-    fill_in 'COMPOSITE--auto_name_3-day', with: '3'
-    fill_in 'COMPOSITE--auto_name_3-month', with: '3'
-    fill_in 'COMPOSITE--auto_name_3-year', with: '1972'
+    fill_in 'COMPOSITE--auto_name_3-day', with: "3"
+    fill_in 'COMPOSITE--auto_name_3-month', with: "3"
+    fill_in 'COMPOSITE--auto_name_3-year', with: "1972"
     continue
 
-   # date
+    # date
     expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Fourth - section heading'
     expect(page).to have_selector 'h1', text: 'Date - Fourth'
     expect(page).to have_selector '.govuk-hint', text: 'Date - Fourth - hint text'
 
-    fill_in 'COMPOSITE--date-fourth-day', with: '4'
-    fill_in 'COMPOSITE--date-fourth-month', with: '4'
-    fill_in 'COMPOSITE--date-fourth-year', with: '1973'
+    fill_in 'COMPOSITE--date-fourth-day', with: "4"
+    fill_in 'COMPOSITE--date-fourth-month', with: "4"
+    fill_in 'COMPOSITE--date-fourth-year', with: "1973"
     continue
 
     # summary
@@ -66,6 +66,23 @@ describe 'Date' do
     expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Date - Fourth - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Date - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: '4 April 1973'
+
+    # Change
+    find('.govuk-summary-list:nth-of-type(4) .govuk-summary-list__actions a').click
+
+    # date
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Fourth - section heading'
+    expect(page).to have_selector 'h1', text: 'Date - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Date - Fourth - hint text'
+
+    fill_in 'COMPOSITE--date-fourth-day', with: "1"
+    fill_in 'COMPOSITE--date-fourth-month', with: "1"
+    fill_in 'COMPOSITE--date-fourth-year', with: "1970"
+    continue
+
+    expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Date - Fourth - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Date - Fourth'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: '1 January 1970'
 
     click_on 'Accept and send application'
 

--- a/tests/spec/email_spec.rb
+++ b/tests/spec/email_spec.rb
@@ -46,6 +46,22 @@ describe 'Email' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Email - Third'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'form-builder-developers@digital.justice.gov.uk'
 
+    # Change
+    find('.govuk-summary-list:nth-of-type(3) .govuk-summary-list__actions a').click
+
+    # email
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Email - Third - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Email - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Email - Third - hint text'
+
+    fill_in 'email-third', with: "form-builder-team@digital.justice.gov.uk"
+    continue
+
+    # summary
+    expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Email - Third - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Email - Third'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'form-builder-team@digital.justice.gov.uk'
+
     click_on 'Accept and send application'
 
     # confirmation

--- a/tests/spec/fieldset_spec.rb
+++ b/tests/spec/fieldset_spec.rb
@@ -12,7 +12,7 @@ describe 'Fieldset' do
 
     expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - First - hint text'
 
-    fill_in 'page_fieldset-first--fieldset--autocomplete_auto_name_1', with: "One\n" # the new line "presses enter" on the selected option
+    fill_in 'page_fieldset-first--fieldset--autocomplete_auto_name_1', with: "One\n" # the new line 'presses enter' on the selected option
 
     # checkboxes
     expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - First - hint text'
@@ -22,9 +22,9 @@ describe 'Fieldset' do
     # date
     expect(page).to have_selector '.govuk-hint', text: 'Date - First - hint text'
 
-    fill_in 'COMPOSITE--auto_name_6-day', with: '1'
-    fill_in 'COMPOSITE--auto_name_6-month', with: '1'
-    fill_in 'COMPOSITE--auto_name_6-year', with: '1970'
+    fill_in 'COMPOSITE--auto_name_6-day', with: "1"
+    fill_in 'COMPOSITE--auto_name_6-month', with: "1"
+    fill_in 'COMPOSITE--auto_name_6-year', with: "1970"
 
     # email
     expect(page).to have_selector '.govuk-hint', text: 'Email - First - hint text'
@@ -74,7 +74,7 @@ describe 'Fieldset' do
 
     expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - Second - hint text'
 
-    fill_in 'page_fieldset-second--fieldset--autocomplete_auto_name_13', with: "Two\n" # the new line "presses enter" on the selected option
+    fill_in 'page_fieldset-second--fieldset--autocomplete_auto_name_13', with: "Two\n" # the new line 'presses enter' on the selected option
 
     # checkboxes
     expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Second - hint text'
@@ -84,9 +84,9 @@ describe 'Fieldset' do
     # date
     expect(page).to have_selector '.govuk-hint', text: 'Date - Second - hint text'
 
-    fill_in 'COMPOSITE--auto_name_18-day', with: '2'
-    fill_in 'COMPOSITE--auto_name_18-month', with: '2'
-    fill_in 'COMPOSITE--auto_name_18-year', with: '1971'
+    fill_in 'COMPOSITE--auto_name_18-day', with: "2"
+    fill_in 'COMPOSITE--auto_name_18-month', with: "2"
+    fill_in 'COMPOSITE--auto_name_18-year', with: "1971"
 
     # email
     expect(page).to have_selector '.govuk-hint', text: 'Email - Second - hint text'
@@ -136,7 +136,7 @@ describe 'Fieldset' do
 
     expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - Third - hint text'
 
-    fill_in 'page_fieldset-third--fieldset--autocomplete_auto_name_25', with: "Three\n" # the new line "presses enter" on the selected option
+    fill_in 'page_fieldset-third--fieldset--autocomplete_auto_name_25', with: "Three\n" # the new line 'presses enter' on the selected option
 
     # checkboxes
     expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Third - hint text'
@@ -146,9 +146,9 @@ describe 'Fieldset' do
     # date
     expect(page).to have_selector '.govuk-hint', text: 'Date - Third - hint text'
 
-    fill_in 'COMPOSITE--auto_name_30-day', with: '3'
-    fill_in 'COMPOSITE--auto_name_30-month', with: '3'
-    fill_in 'COMPOSITE--auto_name_30-year', with: '1972'
+    fill_in 'COMPOSITE--auto_name_30-day', with: "3"
+    fill_in 'COMPOSITE--auto_name_30-month', with: "3"
+    fill_in 'COMPOSITE--auto_name_30-year', with: "1972"
 
     # email
     expect(page).to have_selector '.govuk-hint', text: 'Email - Third - hint text'
@@ -198,7 +198,7 @@ describe 'Fieldset' do
 
     expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - Fourth - hint text'
 
-    fill_in 'page_fieldset-fourth--fieldset--autocomplete_auto_name_37', with: "Four\n" # the new line "presses enter" on the selected option
+    fill_in 'page_fieldset-fourth--fieldset--autocomplete_auto_name_37', with: "Four\n" # the new line 'presses enter' on the selected option
 
     # checkboxes
     expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Fourth - hint text'
@@ -208,9 +208,9 @@ describe 'Fieldset' do
     # date
     expect(page).to have_selector '.govuk-hint', text: 'Date - Fourth - hint text'
 
-    fill_in 'COMPOSITE--auto_name_42-day', with: '4'
-    fill_in 'COMPOSITE--auto_name_42-month', with: '4'
-    fill_in 'COMPOSITE--auto_name_42-year', with: '1973'
+    fill_in 'COMPOSITE--auto_name_42-day', with: "4"
+    fill_in 'COMPOSITE--auto_name_42-month', with: "4"
+    fill_in 'COMPOSITE--auto_name_42-year', with: "1973"
 
     # email
     expect(page).to have_selector '.govuk-hint', text: 'Email - Fourth - hint text'
@@ -385,6 +385,105 @@ describe 'Fieldset' do
 
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__key', text: 'Upload'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__value', text: '4.jpg (1.34MB)'
+
+    # Change
+    find('.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__actions a').click
+
+    # autocomplete
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Fourth - section heading'
+    expect(page).to have_selector 'h1', text: 'Fieldset - Fourth'
+
+    expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - Fourth - hint text'
+
+    fill_in 'page_fieldset-fourth--fieldset--autocomplete_auto_name_37', with: "One\n" # the new line 'presses enter' on the selected option
+
+    # checkboxes
+    expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Fourth - hint text'
+
+    check 'auto_name__38', visible: false
+    check 'auto_name__39', visible: false
+    check 'auto_name__40', visible: false
+
+    # date
+    expect(page).to have_selector '.govuk-hint', text: 'Date - Fourth - hint text'
+
+    fill_in 'COMPOSITE--auto_name_42-day', with: "1"
+    fill_in 'COMPOSITE--auto_name_42-month', with: "1"
+    fill_in 'COMPOSITE--auto_name_42-year', with: "1970"
+
+    # email
+    expect(page).to have_selector '.govuk-hint', text: 'Email - Fourth - hint text'
+
+    fill_in 'page_fieldset-fourth--fieldset--email_auto_name_43', with: "form-builder-team@digital.justice.gov.uk"
+
+    # number
+    expect(page).to have_selector '.govuk-hint', text: 'Number - Fourth - hint text'
+
+    fill_in 'page_fieldset-fourth--fieldset--number_auto_name_44', with: "1"
+
+    # radios
+    expect(page).to have_selector '.govuk-hint', text: 'Radios - Fourth - hint text'
+
+    choose 'auto_name__45', option: '1', visible: false
+
+    # select
+    expect(page).to have_selector '.govuk-hint', text: 'Select - Fourth - hint text'
+
+    select 'One', from: 'page_fieldset-fourth--fieldset--select_auto_name_46'
+
+    # text
+    expect(page).to have_selector '.govuk-hint', text: 'Text - Fourth - hint text'
+
+    fill_in 'page_fieldset-fourth--fieldset--text_auto_name_47', with: "One"
+
+    # textarea
+    expect(page).to have_selector '.govuk-hint', text: 'Textarea - Fourth - hint text'
+
+    fill_in 'page_fieldset-fourth--fieldset--textarea_auto_name_48', with: "One"
+
+    # upload
+    attach_file('auto_name__49[1]', 'spec/fixtures/files/1.jpg')
+
+    continue
+
+    expect(page).to have_selector 'h1', text: 'Fieldset - Fourth - Check'
+    expect(page).to have_selector '.fb-upload-descriptions', text: '1.jpg, 1.34MB'
+
+    # radios
+    choose 'decision', option: 'accept', visible: false
+    continue
+
+    expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Fieldset - Fourth - section heading'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__key', text: 'Autocomplete'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__key', text: 'Checkboxes'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__value', text: /One - summary version\s*Two - summary version\s*Three - summary version\s*Four - summary version/
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__key', text: 'Date'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__value', text: '1 January 1970'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(4) .govuk-summary-list__key', text: 'Email'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(4) .govuk-summary-list__value', text: 'form-builder-team@digital.justice.gov.uk'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(5) .govuk-summary-list__key', text: 'Number'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(5) .govuk-summary-list__value', text: '1'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(6) .govuk-summary-list__key', text: 'Radios'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(6) .govuk-summary-list__value', text: 'One - summary version'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(7) .govuk-summary-list__key', text: 'Select'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(7) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(8) .govuk-summary-list__key', text: 'Text'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(8) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(9) .govuk-summary-list__key', text: 'Textarea'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(9) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__key', text: 'Upload'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__value', text: '1.jpg (1.34MB)'
 
     click_on 'Accept and send application'
 

--- a/tests/spec/number_spec.rb
+++ b/tests/spec/number_spec.rb
@@ -46,6 +46,22 @@ describe 'Number' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Number - Third'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: '3'
 
+    # Change
+    find('.govuk-summary-list:nth-of-type(3) .govuk-summary-list__actions a').click
+
+    # number
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Number - Third - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Number - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Number - Third - hint text'
+
+    fill_in 'number-third', with: "1"
+    continue
+
+    # summary
+    expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Number - Third - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Number - Third'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: '1'
+
     click_on 'Accept and send application'
 
     # confirmation

--- a/tests/spec/radios_spec.rb
+++ b/tests/spec/radios_spec.rb
@@ -58,6 +58,22 @@ describe 'Radios' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Radios - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'Four - summary version'
 
+    # Change
+    find('.govuk-summary-list:nth-of-type(4) .govuk-summary-list__actions a').click
+
+    # radios
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Fourth - section heading'
+    expect(page).to have_selector 'h1', text: 'Radios - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Radios - Fourth - hint text'
+
+    choose 'radios-four', option: '1', visible: false
+    continue
+
+    # summary
+    expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Radios - Fourth - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Radios - Fourth'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'One - summary version'
+
     click_on 'Accept and send application'
 
     # confirmation

--- a/tests/spec/select_spec.rb
+++ b/tests/spec/select_spec.rb
@@ -58,6 +58,22 @@ describe 'Select' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Select - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'Four - summary version'
 
+    # Change
+    find('.govuk-summary-list:nth-of-type(4) .govuk-summary-list__actions a').click
+
+    # select
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Fourth - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Select - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Select - Fourth - hint text'
+
+    select 'One', from: 'page_select-fourth--select_auto_name_4'
+    continue
+
+    # summary
+    expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Select - Fourth - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Select - Fourth'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'One - summary version'
+
     click_on 'Accept and send application'
 
     # confirmation

--- a/tests/spec/text_spec.rb
+++ b/tests/spec/text_spec.rb
@@ -46,6 +46,22 @@ describe 'Text' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Text - Third'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'Three'
 
+    # Change
+    find('.govuk-summary-list:nth-of-type(3) .govuk-summary-list__actions a').click
+
+    # text
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Text - Third - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Text - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Text - Third - hint text'
+
+    fill_in 'text-third', with: "One"
+    continue
+
+    # summary
+    expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Text - Third - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Text - Third'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'One'
+
     click_on 'Accept and send application'
 
     # confirmation

--- a/tests/spec/textarea_spec.rb
+++ b/tests/spec/textarea_spec.rb
@@ -46,6 +46,22 @@ describe 'Textarea' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Textarea - Third'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'Three'
 
+    # Change
+    find('.govuk-summary-list:nth-of-type(3) .govuk-summary-list__actions a').click
+
+    # textarea
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Textarea - Third - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Textarea - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Textarea - Third - hint text'
+
+    fill_in 'textarea-third', with: "One"
+    continue
+
+    # summary
+    expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Textarea - Third - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Textarea - Third'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'One'
+
     click_on 'Accept and send application'
 
     # confirmation

--- a/tests/spec/upload_spec.rb
+++ b/tests/spec/upload_spec.rb
@@ -260,6 +260,31 @@ describe 'Upload' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(6) .govuk-summary-list__key', text: 'Upload - Sixth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(6) .govuk-summary-list__value', text: /1\.jpg \(1\.34MB\)\s*2\.jpg \(1\.34MB\)\s*3\.jpg \(1\.34MB\)/
 
+    # Change
+    find('.govuk-summary-list:nth-of-type(6) .govuk-summary-list__actions a').click
+
+    # upload
+    attach_file('upload-sixth[3]', 'spec/fixtures/files/4.jpg')
+    continue
+
+    expect(page).to have_selector 'h1', text: 'Upload - Sixth - Check'
+    expect(page).to have_selector '.fb-upload-descriptions', text: '4.jpg, 1.34MB'
+
+    choose 'decision', option: 'accept', visible: false
+    continue
+
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Sixth - section heading'
+    expect(page).to have_selector 'h1', text: 'Upload - Sixth - Summary'
+    expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__key', text: 'Upload - Sixth'
+    expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__value', text: '4.jpg, 1.34MB'
+
+    # MAX FILES, NO CONFIRM
+    continue
+
+    expect(page).to have_selector 'h2:nth-of-type(6)', text: 'Upload - Sixth - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(6) .govuk-summary-list__key', text: 'Upload - Sixth'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(6) .govuk-summary-list__value', text: /1\.jpg \(1\.34MB\)\s*2\.jpg \(1\.34MB\)\s*4\.jpg \(1\.34MB\)/
+
     click_on 'Accept and send application'
 
     # confirmation


### PR DESCRIPTION
- Additional tests for `Change` journeys

This is _simple_ at the moment, only supporting the behaviour of `Change` I understand: 

- From any summary page, the user is linked back to a step and can amend a value then re-submit and be returned to the summary page
- For `upload` journeys the user is first sent to the `upload check` step before they can then be returned to the summary page