### PR TITLE
Acceptance tests for "amended `previous` and `next` URL generators" bug

### DIFF
--- a/forms/fieldset/metadata/page/page.fieldset-fourth.json
+++ b/forms/fieldset/metadata/page/page.fieldset-fourth.json
@@ -7,33 +7,33 @@
       "_type": "fieldset",
       "components": [
         {
-          "_id": "page.fieldset-fourth--fieldset--autocomplete.auto_name__37",
+          "_id": "page.fieldset-fourth--fieldset--autocomplete.auto_name__40",
           "_type": "autocomplete",
           "hint": "Autocomplete - Fourth - hint text",
           "items": [
             {
-              "_id": "page.fieldset-fourth--fieldset--autocomplete.auto_name__37--option",
+              "_id": "page.fieldset-fourth--fieldset--autocomplete.auto_name__40--option",
               "_type": "option",
               "text": "One",
               "textSummary": "One - summary version",
               "value": "1"
             },
             {
-              "_id": "page.fieldset-fourth--fieldset--autocomplete.auto_name__37--option--2",
+              "_id": "page.fieldset-fourth--fieldset--autocomplete.auto_name__40--option--2",
               "_type": "option",
               "text": "Two",
               "textSummary": "Two - summary version",
               "value": "2"
             },
             {
-              "_id": "page.fieldset-fourth--fieldset--autocomplete.auto_name__37--option--3",
+              "_id": "page.fieldset-fourth--fieldset--autocomplete.auto_name__40--option--3",
               "_type": "option",
               "text": "Three",
               "textSummary": "Three - summary version",
               "value": "3"
             },
             {
-              "_id": "page.fieldset-fourth--fieldset--autocomplete.auto_name__37--option--4",
+              "_id": "page.fieldset-fourth--fieldset--autocomplete.auto_name__40--option--4",
               "_type": "option",
               "text": "Four",
               "textSummary": "Four - summary version",
@@ -42,7 +42,7 @@
           ],
           "label": "Autocomplete",
           "labelSummary": "Autocomplete - summary version",
-          "name": "auto_name__37"
+          "name": "auto_name__40"
         },
         {
           "_id": "page.fieldset-fourth--fieldset--checkboxes",
@@ -50,68 +50,68 @@
           "hint": "Checkboxes - Fourth - hint text",
           "items": [
             {
-              "_id": "page.fieldset-fourth--fieldset--checkboxes--checkbox.auto_name__38",
+              "_id": "page.fieldset-fourth--fieldset--checkboxes--checkbox.auto_name__41",
               "_type": "checkbox",
               "hint": "Checkbox - One - hint text",
               "label": "One",
               "labelSummary": "One - summary version",
-              "name": "auto_name__38"
+              "name": "auto_name__41"
             },
             {
-              "_id": "page.fieldset-fourth--fieldset--checkboxes--checkbox.auto_name__39",
+              "_id": "page.fieldset-fourth--fieldset--checkboxes--checkbox.auto_name__42",
               "_type": "checkbox",
               "hint": "Checkbox - Two - hint text",
               "label": "Two",
               "labelSummary": "Two - summary version",
-              "name": "auto_name__39"
+              "name": "auto_name__42"
             },
             {
-              "_id": "page.fieldset-fourth--fieldset--checkboxes--checkbox.auto_name__40",
+              "_id": "page.fieldset-fourth--fieldset--checkboxes--checkbox.auto_name__43",
               "_type": "checkbox",
               "hint": "Checkbox - Three - hint text",
               "label": "Three",
               "labelSummary": "Three - summary version",
-              "name": "auto_name__40"
+              "name": "auto_name__43"
             },
             {
-              "_id": "page.fieldset-fourth--fieldset--checkboxes--checkbox.auto_name__41",
+              "_id": "page.fieldset-fourth--fieldset--checkboxes--checkbox.auto_name__44",
               "_type": "checkbox",
               "hint": "Checkbox - Four - hint text",
               "label": "Four",
               "labelSummary": "Four - summary version",
-              "name": "auto_name__41"
+              "name": "auto_name__44"
             }
           ],
           "legend": "Checkboxes"
         },
         {
-          "_id": "page.fieldset-fourth--fieldset--date.auto_name__42",
+          "_id": "page.fieldset-fourth--fieldset--date.auto_name__45",
           "_type": "date",
           "hint": "Date - Fourth - hint text",
           "legend": "Date",
-          "name": "auto_name__42"
+          "name": "auto_name__45"
         },
         {
-          "_id": "page.fieldset-fourth--fieldset--email.auto_name__43",
+          "_id": "page.fieldset-fourth--fieldset--email.auto_name__46",
           "_type": "email",
           "hint": "Email - Fourth - hint text",
           "label": "Email",
-          "name": "auto_name__43"
+          "name": "auto_name__46"
         },
         {
-          "_id": "page.fieldset-fourth--fieldset--number.auto_name__44",
+          "_id": "page.fieldset-fourth--fieldset--number.auto_name__47",
           "_type": "number",
           "hint": "Number - Fourth - hint text",
           "label": "Number",
-          "name": "auto_name__44"
+          "name": "auto_name__47"
         },
         {
-          "_id": "page.fieldset-fourth--fieldset--radios.auto_name__45",
+          "_id": "page.fieldset-fourth--fieldset--radios.auto_name__48",
           "_type": "radios",
           "hint": "Radios - Fourth - hint text",
           "items": [
             {
-              "_id": "page.fieldset-fourth--fieldset--radios.auto_name__45--radio.auto_value__1",
+              "_id": "page.fieldset-fourth--fieldset--radios.auto_name__48--radio.auto_value__1",
               "_type": "radio",
               "hint": "Radio - One - hint text",
               "label": "One",
@@ -119,7 +119,7 @@
               "value": "1"
             },
             {
-              "_id": "page.fieldset-fourth--fieldset--radios.auto_name__45--radio.auto_value__2",
+              "_id": "page.fieldset-fourth--fieldset--radios.auto_name__48--radio.auto_value__2",
               "_type": "radio",
               "hint": "Radio - Two - hint text",
               "label": "Two",
@@ -127,7 +127,7 @@
               "value": "2"
             },
             {
-              "_id": "page.fieldset-fourth--fieldset--radios.auto_name__45--radio.auto_value__3",
+              "_id": "page.fieldset-fourth--fieldset--radios.auto_name__48--radio.auto_value__3",
               "_type": "radio",
               "hint": "Radio - Three - hint text",
               "label": "Three",
@@ -135,7 +135,7 @@
               "value": "3"
             },
             {
-              "_id": "page.fieldset-fourth--fieldset--radios.auto_name__45--radio.auto_value__4",
+              "_id": "page.fieldset-fourth--fieldset--radios.auto_name__48--radio.auto_value__4",
               "_type": "radio",
               "hint": "Radio - Four - hint text",
               "label": "Four",
@@ -144,36 +144,36 @@
             }
           ],
           "legend": "Radios",
-          "name": "auto_name__45"
+          "name": "auto_name__48"
         },
         {
-          "_id": "page.fieldset-fourth--fieldset--select.auto_name__46",
+          "_id": "page.fieldset-fourth--fieldset--select.auto_name__49",
           "_type": "select",
           "hint": "Select - Fourth - hint text",
           "items": [
             {
-              "_id": "page.fieldset-fourth--fieldset--select.auto_name__46--option",
+              "_id": "page.fieldset-fourth--fieldset--select.auto_name__49--option",
               "_type": "option",
               "text": "One",
               "textSummary": "One - summary version",
               "value": "1"
             },
             {
-              "_id": "page.fieldset-fourth--fieldset--select.auto_name__46--option--2",
+              "_id": "page.fieldset-fourth--fieldset--select.auto_name__49--option--2",
               "_type": "option",
               "text": "Two",
               "textSummary": "Two - summary version",
               "value": "2"
             },
             {
-              "_id": "page.fieldset-fourth--fieldset--select.auto_name__46--option--3",
+              "_id": "page.fieldset-fourth--fieldset--select.auto_name__49--option--3",
               "_type": "option",
               "text": "Three",
               "textSummary": "Three - summary version",
               "value": "3"
             },
             {
-              "_id": "page.fieldset-fourth--fieldset--select.auto_name__46--option--4",
+              "_id": "page.fieldset-fourth--fieldset--select.auto_name__49--option--4",
               "_type": "option",
               "text": "Four",
               "textSummary": "Four - summary version",
@@ -182,28 +182,28 @@
           ],
           "label": "Select",
           "labelSummary": "Select - summary version",
-          "name": "auto_name__46"
+          "name": "auto_name__49"
         },
         {
-          "_id": "page.fieldset-fourth--fieldset--text.auto_name__47",
+          "_id": "page.fieldset-fourth--fieldset--text.auto_name__50",
           "_type": "text",
           "hint": "Text - Fourth - hint text",
           "label": "Text",
-          "name": "auto_name__47"
+          "name": "auto_name__50"
         },
         {
-          "_id": "page.fieldset-fourth--fieldset--textarea.auto_name__48",
+          "_id": "page.fieldset-fourth--fieldset--textarea.auto_name__51",
           "_type": "textarea",
           "hint": "Textarea - Fourth - hint text",
           "label": "Textarea",
-          "name": "auto_name__48"
+          "name": "auto_name__51"
         },
         {
-          "_id": "page.fieldset-first--fieldset--upload.auto_name__49",
+          "_id": "page.fieldset-first--fieldset--upload.auto_name__52",
           "_type": "upload",
           "hint": "Upload - Fourth - hint text",
           "label": "Upload",
-          "name": "auto_name__49"
+          "name": "auto_name__52"
         }
       ],
       "legend": "Fieldset - Fourth"

--- a/forms/fieldset/metadata/page/page.fieldset-second.json
+++ b/forms/fieldset/metadata/page/page.fieldset-second.json
@@ -7,30 +7,30 @@
       "_type": "fieldset",
       "components": [
         {
-          "_id": "page.fieldset-second--fieldset--autocomplete.auto_name__13",
+          "_id": "page.fieldset-second--fieldset--autocomplete.auto_name__14",
           "_type": "autocomplete",
           "hint": "Autocomplete - Second - hint text",
           "items": [
             {
-              "_id": "page.fieldset-second--fieldset--autocomplete.auto_name__13--option",
+              "_id": "page.fieldset-second--fieldset--autocomplete.auto_name__14--option",
               "_type": "option",
               "text": "One",
               "value": "1"
             },
             {
-              "_id": "page.fieldset-second--fieldset--autocomplete.auto_name__13--option--2",
+              "_id": "page.fieldset-second--fieldset--autocomplete.auto_name__14--option--2",
               "_type": "option",
               "text": "Two",
               "value": "2"
             },
             {
-              "_id": "page.fieldset-second--fieldset--autocomplete.auto_name__13--option--3",
+              "_id": "page.fieldset-second--fieldset--autocomplete.auto_name__14--option--3",
               "_type": "option",
               "text": "Three",
               "value": "3"
             },
             {
-              "_id": "page.fieldset-second--fieldset--autocomplete.auto_name__13--option--4",
+              "_id": "page.fieldset-second--fieldset--autocomplete.auto_name__14--option--4",
               "_type": "option",
               "text": "Four",
               "value": "4"
@@ -38,7 +38,7 @@
           ],
           "label": "Autocomplete",
           "labelSummary": "Autocomplete - summary version",
-          "name": "auto_name__13"
+          "name": "auto_name__14"
         },
         {
           "_id": "page.fieldset-second--fieldset--checkboxes",
@@ -46,89 +46,89 @@
           "hint": "Checkboxes - Second - hint text",
           "items": [
             {
-              "_id": "page.fieldset-second--fieldset--checkboxes--checkbox.auto_name__14",
+              "_id": "page.fieldset-second--fieldset--checkboxes--checkbox.auto_name__15",
               "_type": "checkbox",
               "hint": "Checkbox - One - hint text",
               "label": "One",
-              "name": "auto_name__14",
-              "value": "1"
-            },
-            {
-              "_id": "page.fieldset-second--fieldset--checkboxes--checkbox.auto_name__15",
-              "_type": "checkbox",
-              "hint": "Checkbox - Two - hint text",
-              "label": "Two",
               "name": "auto_name__15",
-              "value": "2"
+              "value": "1"
             },
             {
               "_id": "page.fieldset-second--fieldset--checkboxes--checkbox.auto_name__16",
               "_type": "checkbox",
-              "hint": "Checkbox - Three - hint text",
-              "label": "Three",
+              "hint": "Checkbox - Two - hint text",
+              "label": "Two",
               "name": "auto_name__16",
-              "value": "3"
+              "value": "2"
             },
             {
               "_id": "page.fieldset-second--fieldset--checkboxes--checkbox.auto_name__17",
               "_type": "checkbox",
+              "hint": "Checkbox - Three - hint text",
+              "label": "Three",
+              "name": "auto_name__17",
+              "value": "3"
+            },
+            {
+              "_id": "page.fieldset-second--fieldset--checkboxes--checkbox.auto_name__18",
+              "_type": "checkbox",
               "hint": "Checkbox - Four - hint text",
               "label": "Four",
-              "name": "auto_name__17",
+              "name": "auto_name__18",
               "value": "4"
             }
           ],
           "legend": "Checkboxes"
         },
         {
-          "_id": "page.fieldset-second--fieldset--date.auto_name__18",
+          "_id": "page.fieldset-second--fieldset--date.auto_name__19",
           "_type": "date",
           "hint": "Date - Second - hint text",
           "legend": "Date",
-          "name": "auto_name__18"
-        },
-        {
-          "_id": "page.fieldset-second--fieldset--email.auto_name__19",
-          "_type": "email",
-          "hint": "Email - Second - hint text",
-          "label": "Email",
           "name": "auto_name__19"
         },
         {
-          "_id": "page.fieldset-second--fieldset--number.auto_name__20",
-          "_type": "number",
-          "hint": "Number - Second - hint text",
-          "label": "Number",
+          "_id": "page.fieldset-second--fieldset--email.auto_name__20",
+          "_type": "email",
+          "hint": "Email - Second - hint text",
+          "label": "Email",
           "name": "auto_name__20"
         },
         {
-          "_id": "page.fieldset-second--fieldset--radios.auto_name__21",
+          "_id": "page.fieldset-second--fieldset--number.auto_name__21",
+          "_type": "number",
+          "hint": "Number - Second - hint text",
+          "label": "Number",
+          "name": "auto_name__21"
+        },
+        {
+          "_id": "page.fieldset-second--fieldset--radios.auto_name__22",
           "_type": "radios",
           "hint": "Radios - Second - hint text",
           "items": [
             {
-              "_id": "page.fieldset-second--fieldset--radios.auto_name__21--radio.auto_value__1",
+              "_id": "page.fieldset-second--fieldset--radios.auto_name__22--radio.auto_value__1",
               "_type": "radio",
               "hint": "Radio - One - hint text",
               "label": "One",
               "value": "1"
             },
             {
-              "_id": "page.fieldset-second--fieldset--radios.auto_name__21--radio.auto_value__2",
+              "_id": "page.fieldset-second--fieldset--radios.auto_name__22--radio.auto_value__2",
               "_type": "radio",
               "hint": "Radio - Two - hint text",
               "label": "Two",
               "value": "2"
             },
             {
-              "_id": "page.fieldset-second--fieldset--radios.auto_name__21--radio.auto_value__3",
+              "_id": "page.fieldset-second--fieldset--radios.auto_name__22--radio.auto_value__3",
               "_type": "radio",
               "hint": "Radio - Three - hint text",
               "label": "Three",
               "value": "3"
             },
             {
-              "_id": "page.fieldset-second--fieldset--radios.auto_name__21--radio.auto_value__4",
+              "_id": "page.fieldset-second--fieldset--radios.auto_name__22--radio.auto_value__4",
               "_type": "radio",
               "hint": "Radio - Four - hint text",
               "label": "Four",
@@ -136,33 +136,33 @@
             }
           ],
           "legend": "Radios",
-          "name": "auto_name__21"
+          "name": "auto_name__22"
         },
         {
-          "_id": "page.fieldset-second--fieldset--select.auto_name__22",
+          "_id": "page.fieldset-second--fieldset--select.auto_name__23",
           "_type": "select",
           "hint": "Select - Second - hint text",
           "items": [
             {
-              "_id": "page.fieldset-second--fieldset--select.auto_name__22--option",
+              "_id": "page.fieldset-second--fieldset--select.auto_name__23--option",
               "_type": "option",
               "text": "One",
               "value": "1"
             },
             {
-              "_id": "page.fieldset-second--fieldset--select.auto_name__22--option--2",
+              "_id": "page.fieldset-second--fieldset--select.auto_name__23--option--2",
               "_type": "option",
               "text": "Two",
               "value": "2"
             },
             {
-              "_id": "page.fieldset-second--fieldset--select.auto_name__22--option--3",
+              "_id": "page.fieldset-second--fieldset--select.auto_name__23--option--3",
               "_type": "option",
               "text": "Three",
               "value": "3"
             },
             {
-              "_id": "page.fieldset-second--fieldset--select.auto_name__22--option--4",
+              "_id": "page.fieldset-second--fieldset--select.auto_name__23--option--4",
               "_type": "option",
               "text": "Four",
               "value": "4"
@@ -170,28 +170,28 @@
           ],
           "label": "Select",
           "labelSummary": "Select - summary version",
-          "name": "auto_name__22"
-        },
-        {
-          "_id": "page.fieldset-second--fieldset--text.auto_name__23",
-          "_type": "text",
-          "hint": "Text - Second - hint text",
-          "label": "Text",
           "name": "auto_name__23"
         },
         {
-          "_id": "page.fieldset-second--fieldset--textarea.auto_name__24",
-          "_type": "textarea",
-          "hint": "Textarea - Second - hint text",
-          "label": "Textarea",
+          "_id": "page.fieldset-second--fieldset--text.auto_name__24",
+          "_type": "text",
+          "hint": "Text - Second - hint text",
+          "label": "Text",
           "name": "auto_name__24"
         },
         {
-          "_id": "page.fieldset-first--fieldset--upload.auto_name__25",
+          "_id": "page.fieldset-second--fieldset--textarea.auto_name__25",
+          "_type": "textarea",
+          "hint": "Textarea - Second - hint text",
+          "label": "Textarea",
+          "name": "auto_name__25"
+        },
+        {
+          "_id": "page.fieldset-first--fieldset--upload.auto_name__26",
           "_type": "upload",
           "hint": "Upload - Second - hint text",
           "label": "Upload",
-          "name": "auto_name__25"
+          "name": "auto_name__26"
         }
       ],
       "legend": "Fieldset - Second"

--- a/forms/fieldset/metadata/page/page.fieldset-third.json
+++ b/forms/fieldset/metadata/page/page.fieldset-third.json
@@ -7,33 +7,33 @@
       "_type": "fieldset",
       "components": [
         {
-          "_id": "page.fieldset-third--fieldset--autocomplete.auto_name__25",
+          "_id": "page.fieldset-third--fieldset--autocomplete.auto_name__27",
           "_type": "autocomplete",
           "hint": "Autocomplete - Third - hint text",
           "items": [
             {
-              "_id": "page.fieldset-third--fieldset--autocomplete.auto_name__25--option",
+              "_id": "page.fieldset-third--fieldset--autocomplete.auto_name__27--option",
               "_type": "option",
               "text": "One",
               "textSummary": "One - summary version",
               "value": "1"
             },
             {
-              "_id": "page.fieldset-third--fieldset--autocomplete.auto_name__25--option--2",
+              "_id": "page.fieldset-third--fieldset--autocomplete.auto_name__27--option--2",
               "_type": "option",
               "text": "Two",
               "textSummary": "Two - summary version",
               "value": "2"
             },
             {
-              "_id": "page.fieldset-third--fieldset--autocomplete.auto_name__25--option--3",
+              "_id": "page.fieldset-third--fieldset--autocomplete.auto_name__27--option--3",
               "_type": "option",
               "text": "Three",
               "textSummary": "Three - summary version",
               "value": "3"
             },
             {
-              "_id": "page.fieldset-third--fieldset--autocomplete.auto_name__25--option--4",
+              "_id": "page.fieldset-third--fieldset--autocomplete.auto_name__27--option--4",
               "_type": "option",
               "text": "Four",
               "textSummary": "Four - summary version",
@@ -42,7 +42,7 @@
           ],
           "label": "Autocomplete",
           "labelSummary": "Autocomplete - summary version",
-          "name": "auto_name__25"
+          "name": "auto_name__27"
         },
         {
           "_id": "page.fieldset-third--fieldset--checkboxes",
@@ -50,68 +50,68 @@
           "hint": "Checkboxes - Third - hint text",
           "items": [
             {
-              "_id": "page.fieldset-third--fieldset--checkboxes--checkbox.auto_name__26",
+              "_id": "page.fieldset-third--fieldset--checkboxes--checkbox.auto_name__28",
               "_type": "checkbox",
               "hint": "Checkbox - One - hint text",
               "label": "One",
               "labelSummary": "One - summary version",
-              "name": "auto_name__26"
-            },
-            {
-              "_id": "page.fieldset-third--fieldset--checkboxes--checkbox.auto_name__27",
-              "_type": "checkbox",
-              "hint": "Checkbox - Two - hint text",
-              "label": "Two",
-              "labelSummary": "Two - summary version",
-              "name": "auto_name__27"
-            },
-            {
-              "_id": "page.fieldset-third--fieldset--checkboxes--checkbox.auto_name__28",
-              "_type": "checkbox",
-              "hint": "Checkbox - Three - hint text",
-              "label": "Three",
-              "labelSummary": "Three - summary version",
               "name": "auto_name__28"
             },
             {
               "_id": "page.fieldset-third--fieldset--checkboxes--checkbox.auto_name__29",
               "_type": "checkbox",
+              "hint": "Checkbox - Two - hint text",
+              "label": "Two",
+              "labelSummary": "Two - summary version",
+              "name": "auto_name__29"
+            },
+            {
+              "_id": "page.fieldset-third--fieldset--checkboxes--checkbox.auto_name__30",
+              "_type": "checkbox",
+              "hint": "Checkbox - Three - hint text",
+              "label": "Three",
+              "labelSummary": "Three - summary version",
+              "name": "auto_name__30"
+            },
+            {
+              "_id": "page.fieldset-third--fieldset--checkboxes--checkbox.auto_name__31",
+              "_type": "checkbox",
               "hint": "Checkbox - Four - hint text",
               "label": "Four",
               "labelSummary": "Four - summary version",
-              "name": "auto_name__29"
+              "name": "auto_name__31"
             }
           ],
           "legend": "Checkboxes"
         },
         {
-          "_id": "page.fieldset-third--fieldset--date.auto_name__30",
+          "_id": "page.fieldset-third--fieldset--date.auto_name__32",
           "_type": "date",
           "hint": "Date - Third - hint text",
           "legend": "Date",
-          "name": "auto_name__30"
-        },
-        {
-          "_id": "page.fieldset-third--fieldset--email.auto_name__31",
-          "_type": "email",
-          "hint": "Email - Third - hint text",
-          "label": "Email",
-          "name": "auto_name__31"
-        },
-        {
-          "_id": "page.fieldset-third--fieldset--number.auto_name__32",
-          "_type": "number",
-          "hint": "Number - Third - hint text",
-          "label": "Number",
           "name": "auto_name__32"
         },
         {
-          "_id": "page.fieldset-third--fieldset--radios.auto_name__33",
+          "_id": "page.fieldset-third--fieldset--email.auto_name__33",
+          "_type": "email",
+          "hint": "Email - Third - hint text",
+          "label": "Email",
+          "name": "auto_name__33"
+        },
+        {
+          "_id": "page.fieldset-third--fieldset--number.auto_name__34",
+          "_type": "number",
+          "hint": "Number - Third - hint text",
+          "label": "Number",
+          "name": "auto_name__34"
+        },
+        {
+          "_id": "page.fieldset-third--fieldset--radios.auto_name__35",
           "_type": "radios",
           "hint": "Radios - Third - hint text",
           "items": [
             {
-              "_id": "page.fieldset-third--fieldset--radios.auto_name__33--radio.auto_value__1",
+              "_id": "page.fieldset-third--fieldset--radios.auto_name__35--radio.auto_value__1",
               "_type": "radio",
               "hint": "Radio - One - hint text",
               "label": "One",
@@ -119,7 +119,7 @@
               "value": "1"
             },
             {
-              "_id": "page.fieldset-third--fieldset--radios.auto_name__33--radio.auto_value__2",
+              "_id": "page.fieldset-third--fieldset--radios.auto_name__35--radio.auto_value__2",
               "_type": "radio",
               "hint": "Radio - Two - hint text",
               "label": "Two",
@@ -127,7 +127,7 @@
               "value": "2"
             },
             {
-              "_id": "page.fieldset-third--fieldset--radios.auto_name__33--radio.auto_value__3",
+              "_id": "page.fieldset-third--fieldset--radios.auto_name__35--radio.auto_value__3",
               "_type": "radio",
               "hint": "Radio - Three - hint text",
               "label": "Three",
@@ -135,7 +135,7 @@
               "value": "3"
             },
             {
-              "_id": "page.fieldset-third--fieldset--radios.auto_name__33--radio.auto_value__4",
+              "_id": "page.fieldset-third--fieldset--radios.auto_name__35--radio.auto_value__4",
               "_type": "radio",
               "hint": "Radio - Four - hint text",
               "label": "Four",
@@ -144,36 +144,36 @@
             }
           ],
           "legend": "Radios",
-          "name": "auto_name__33"
+          "name": "auto_name__35"
         },
         {
-          "_id": "page.fieldset-third--fieldset--select.auto_name__34",
+          "_id": "page.fieldset-third--fieldset--select.auto_name__36",
           "_type": "select",
           "hint": "Select - Third - hint text",
           "items": [
             {
-              "_id": "page.fieldset-third--fieldset--select.auto_name__34--option",
+              "_id": "page.fieldset-third--fieldset--select.auto_name__36--option",
               "_type": "option",
               "text": "One",
               "textSummary": "One - summary version",
               "value": "1"
             },
             {
-              "_id": "page.fieldset-third--fieldset--select.auto_name__34--option--2",
+              "_id": "page.fieldset-third--fieldset--select.auto_name__36--option--2",
               "_type": "option",
               "text": "Two",
               "textSummary": "Two - summary version",
               "value": "2"
             },
             {
-              "_id": "page.fieldset-third--fieldset--select.auto_name__34--option--3",
+              "_id": "page.fieldset-third--fieldset--select.auto_name__36--option--3",
               "_type": "option",
               "text": "Three",
               "textSummary": "Three - summary version",
               "value": "3"
             },
             {
-              "_id": "page.fieldset-third--fieldset--select.auto_name__34--option--4",
+              "_id": "page.fieldset-third--fieldset--select.auto_name__36--option--4",
               "_type": "option",
               "text": "Four",
               "textSummary": "Four - summary version",
@@ -182,28 +182,28 @@
           ],
           "label": "Select",
           "labelSummary": "Select - summary version",
-          "name": "auto_name__34"
-        },
-        {
-          "_id": "page.fieldset-third--fieldset--text.auto_name__35",
-          "_type": "text",
-          "hint": "Text - Third - hint text",
-          "label": "Text",
-          "name": "auto_name__35"
-        },
-        {
-          "_id": "page.fieldset-third--fieldset--textarea.auto_name__36",
-          "_type": "textarea",
-          "hint": "Textarea - Third - hint text",
-          "label": "Textarea",
           "name": "auto_name__36"
         },
         {
-          "_id": "page.fieldset-first--fieldset--upload.auto_name__37",
+          "_id": "page.fieldset-third--fieldset--text.auto_name__37",
+          "_type": "text",
+          "hint": "Text - Third - hint text",
+          "label": "Text",
+          "name": "auto_name__37"
+        },
+        {
+          "_id": "page.fieldset-third--fieldset--textarea.auto_name__38",
+          "_type": "textarea",
+          "hint": "Textarea - Third - hint text",
+          "label": "Textarea",
+          "name": "auto_name__38"
+        },
+        {
+          "_id": "page.fieldset-first--fieldset--upload.auto_name__39",
           "_type": "upload",
           "hint": "Upload - Third - hint text",
           "label": "Upload",
-          "name": "auto_name__37"
+          "name": "auto_name__39"
         }
       ],
       "legend": "Fieldset - Third"

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -3,7 +3,6 @@
 set -ex
 
 # adds a test token to use in end to end test
-docker-compose exec service-token-cache-app sh -c "bundle exec rails runner \"Support::ServiceTokenCache.put('slug', 'token-for-slug')\""
 docker-compose exec service-token-cache-app sh -c "bundle exec rails runner \"Adapters::RedisCacheAdapter.put('encoded-public-key-slug', 'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUEzU1RCMkxnaDAyWWt0K0xxejluNgo5MlNwV0xFdXNUR1hEMGlmWTBuRHpmbXF4MWVlbHoxeHhwSk9MZXRyTGdxbjM3aE1qTlkwL25BQ2NNZHVFSDlLClhycmFieFhYVGwxeVkyMStnbVd4NDlOZVlESW5iZG0rNnM1S3ZMZ1VOTjdYVmNlUDlQdXFaeXN4Q1ZBNFRubUwKRURLZ2xTV2JVeWZ0QmVhVENKVkk2NFoxMmRNdFBiQWd4V0FmZVNMbGI3QlBsc0htL0gwQUFMK25iYU9Da3d2cgpQSkRMVFZPek9XSE1vR2dzMnJ4akJIRC9OV05ac1RWUWFvNFh3aGVidWRobHZNaWtFVzMyV0tnS3VISFc4emR2ClU4TWozM1RYK1picVhPaWtkRE54dHd2a1hGN0xBM1loOExJNUd5ZDlwNmYyN01mbGRnVUlIU3hjSnB5MUo4QVAKcXdJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg==')\""
 
 docker-compose exec localstack sh -c "AWS_ACCESS_KEY_ID=qwerty AWS_SECRET_KEY=qwerty AWS_SECRET_ACCESS_KEY=qwerty aws --endpoint-url=http://localhost:4572 s3 mb s3://filestore-bucket"

--- a/tests/spec/autocomplete_spec.rb
+++ b/tests/spec/autocomplete_spec.rb
@@ -58,7 +58,13 @@ describe 'Autocomplete' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Autocomplete - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'Four - summary version'
 
-    # Change
+    ########################################
+    #                                      #
+    #   CHANGE                             #
+    #                                      #
+    ########################################
+
+    # change
     find('.govuk-summary-list:nth-of-type(4) .govuk-summary-list__actions a').click
 
     # autocomplete
@@ -73,6 +79,47 @@ describe 'Autocomplete' do
     expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Autocomplete - Fourth - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Autocomplete - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'One - summary version'
+
+    ########################################
+    #                                      #
+    #   BACK                               #
+    #                                      #
+    ########################################
+
+    # back
+    find('.govuk-back-link').click
+
+    # fourth
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Fourth - section heading'
+    find('.govuk-back-link').click
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Third - section heading'
+    find('.govuk-back-link').click
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Second - section heading'
+    find('.govuk-back-link').click
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - First - section heading'
+    continue
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Second - section heading'
+    continue
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Third - section heading'
+    continue
+
+    # fourth
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Fourth - section heading'
+    continue
+
+    # summary
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Summary - section heading'
+    expect(page).to have_selector 'h1', text: 'Summary'
 
     click_on 'Accept and send application'
 

--- a/tests/spec/autocomplete_spec.rb
+++ b/tests/spec/autocomplete_spec.rb
@@ -38,6 +38,12 @@ describe 'Autocomplete' do
     fill_in 'page_autocomplete-fourth--autocomplete_auto_name_4', with: "Four\n" # the new line "presses enter" on the selected option
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
@@ -75,6 +81,12 @@ describe 'Autocomplete' do
     fill_in 'page_autocomplete-fourth--autocomplete_auto_name_4', with: "One\n" # the new line 'presses enter' on the selected option
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Autocomplete - Fourth - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Autocomplete - Fourth'
@@ -87,35 +99,92 @@ describe 'Autocomplete' do
     ########################################
 
     # back
-    find('.govuk-back-link').click
+    back
 
     # fourth
     expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Fourth - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Autocomplete - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - Fourth - hint text'
+
+    expect(find_field('page_autocomplete-fourth--autocomplete_auto_name_4').value).to eq 'One'
+    back
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Third - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Autocomplete - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - Third - hint text'
+
+    expect(find_field('page_autocomplete-third--autocomplete_auto_name_3').value).to eq 'Three'
+    back
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Second - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Autocomplete - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - Second - hint text'
+
+    expect(find_field('page_autocomplete-second--autocomplete_auto_name_2').value).to eq 'Two'
+    back
 
     # first
     expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - First - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Autocomplete - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - First - hint text'
+
+    expect(find_field('page_autocomplete-first--autocomplete_auto_name_1').value).to eq 'One'
+    back
+
+    ########################################
+    #                                      #
+    #   START                              #
+    #                                      #
+    ########################################
+
+    # start
+    click_on 'Start'
+
+    ########################################
+    #                                      #
+    #   FORWARD                            #
+    #                                      #
+    ########################################
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - First - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Autocomplete - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - First - hint text'
+
+    expect(find_field('page_autocomplete-first--autocomplete_auto_name_1').value).to eq 'One'
     continue
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Second - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Autocomplete - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - Second - hint text'
+
+    expect(find_field('page_autocomplete-second--autocomplete_auto_name_2').value).to eq 'Two'
     continue
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Third - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Autocomplete - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - Third - hint text'
+
+    expect(find_field('page_autocomplete-third--autocomplete_auto_name_3').value).to eq 'Three'
     continue
 
     # fourth
     expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Fourth - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Autocomplete - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - Fourth - hint text'
+
+    expect(find_field('page_autocomplete-fourth--autocomplete_auto_name_4').value).to eq 'One'
     continue
+
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
 
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Autocomplete - Summary - section heading'
@@ -125,6 +194,10 @@ describe 'Autocomplete' do
 
     # confirmation
     expect(page).to have_selector 'h1.govuk-panel__title', text: 'Autocomplete - Confirmation'
+  end
+
+  def back
+    find('.govuk-back-link').click
   end
 
   def continue

--- a/tests/spec/checkboxes_spec.rb
+++ b/tests/spec/checkboxes_spec.rb
@@ -61,7 +61,13 @@ describe 'Checkboxes' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Checkboxes - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: /One - summary version\s*Two - summary version\s*Three - summary version\s*Four - summary version/
 
-    # Change
+    ########################################
+    #                                      #
+    #   CHANGE                             #
+    #                                      #
+    ########################################
+
+    # change
     find('.govuk-summary-list:nth-of-type(4) .govuk-summary-list__actions a').click
 
     # checkboxes
@@ -78,6 +84,47 @@ describe 'Checkboxes' do
     expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Checkboxes - Fourth - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Checkboxes - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'Four - summary version'
+
+    ########################################
+    #                                      #
+    #   BACK                               #
+    #                                      #
+    ########################################
+
+    # back
+    find('.govuk-back-link').click
+
+    # fourth
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Fourth - section heading'
+    find('.govuk-back-link').click
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Third - section heading'
+    find('.govuk-back-link').click
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Second - section heading'
+    find('.govuk-back-link').click
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - First - section heading'
+    continue
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Second - section heading'
+    continue
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Third - section heading'
+    continue
+
+    # fourth
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Fourth - section heading'
+    continue
+
+    # summary
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Summary - section heading'
+    expect(page).to have_selector 'h1', text: 'Summary'
 
     click_on 'Accept and send application'
 

--- a/tests/spec/checkboxes_spec.rb
+++ b/tests/spec/checkboxes_spec.rb
@@ -41,6 +41,12 @@ describe 'Checkboxes' do
     check 'checkboxes-four', visible: false
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
@@ -75,10 +81,16 @@ describe 'Checkboxes' do
     expect(page).to have_selector 'h1', text: 'Checkboxes - Fourth'
     expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Fourth - hint text'
 
-    check 'checkboxes-one', visible: false
-    check 'checkboxes-two', visible: false
-    check 'checkboxes-three', visible: false
+    uncheck 'checkboxes-one', visible: false
+    uncheck 'checkboxes-two', visible: false
+    uncheck 'checkboxes-three', visible: false
     continue
+
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
 
     # summary
     expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Checkboxes - Fourth - section heading'
@@ -92,44 +104,145 @@ describe 'Checkboxes' do
     ########################################
 
     # back
-    find('.govuk-back-link').click
+    back
 
     # fourth
     expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Fourth - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1', text: 'Checkboxes - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Fourth - hint text'
+
+    expect(page).to have_field('checkboxes-one', visible: false, checked: false)
+    expect(page).to have_field('checkboxes-two', visible: false, checked: false)
+    expect(page).to have_field('checkboxes-three', visible: false, checked: false)
+    expect(page).to have_field('checkboxes-four', visible: false, checked: true)
+    back
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Third - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1', text: 'Checkboxes - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Third - hint text'
+
+    expect(page).to have_field('auto_name__9', visible: false, checked: false)
+    expect(page).to have_field('auto_name__10', visible: false, checked: false)
+    expect(page).to have_field('auto_name__11', visible: false, checked: true)
+    expect(page).to have_field('auto_name__12', visible: false, checked: false)
+    back
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Second - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1', text: 'Checkboxes - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Second - hint text'
+
+    expect(page).to have_field('auto_name__5', visible: false, checked: false)
+    expect(page).to have_field('auto_name__6', visible: false, checked: true)
+    expect(page).to have_field('auto_name__7', visible: false, checked: false)
+    expect(page).to have_field('auto_name__8', visible: false, checked: false)
+    back
 
     # first
     expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - First - section heading'
+    expect(page).to have_selector 'h1', text: 'Checkboxes - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - First - hint text'
+
+    expect(page).to have_field('auto_name__1', visible: false, checked: true)
+    expect(page).to have_field('auto_name__2', visible: false, checked: false)
+    expect(page).to have_field('auto_name__3', visible: false, checked: false)
+    expect(page).to have_field('auto_name__4', visible: false, checked: false)
+    back
+
+    ########################################
+    #                                      #
+    #   START                              #
+    #                                      #
+    ########################################
+
+    # start
+    click_on 'Start'
+
+    ########################################
+    #                                      #
+    #   FORWARD                            #
+    #                                      #
+    ########################################
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - First - section heading'
+    expect(page).to have_selector 'h1', text: 'Checkboxes - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - First - hint text'
+
+    expect(page).to have_field('auto_name__1', visible: false, checked: true)
+    expect(page).to have_field('auto_name__2', visible: false, checked: false)
+    expect(page).to have_field('auto_name__3', visible: false, checked: false)
+    expect(page).to have_field('auto_name__4', visible: false, checked: false)
     continue
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Second - section heading'
+    expect(page).to have_selector 'h1', text: 'Checkboxes - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Second - hint text'
+
+    expect(page).to have_field('auto_name__5', visible: false, checked: false)
+    expect(page).to have_field('auto_name__6', visible: false, checked: true)
+    expect(page).to have_field('auto_name__7', visible: false, checked: false)
+    expect(page).to have_field('auto_name__8', visible: false, checked: false)
     continue
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Third - section heading'
+    expect(page).to have_selector 'h1', text: 'Checkboxes - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Third - hint text'
+
+    expect(page).to have_field('auto_name__9', visible: false, checked: false)
+    expect(page).to have_field('auto_name__10', visible: false, checked: false)
+    expect(page).to have_field('auto_name__11', visible: false, checked: true)
+    expect(page).to have_field('auto_name__12', visible: false, checked: false)
     continue
 
     # fourth
     expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Fourth - section heading'
+    expect(page).to have_selector 'h1', text: 'Checkboxes - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Fourth - hint text'
+
+    expect(page).to have_field('checkboxes-one', visible: false, checked: false)
+    expect(page).to have_field('checkboxes-two', visible: false, checked: false)
+    expect(page).to have_field('checkboxes-three', visible: false, checked: false)
+    expect(page).to have_field('checkboxes-four', visible: false, checked: true)
     continue
+
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
 
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Checkboxes - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
 
+    expect(page).to have_selector 'h2:nth-of-type(1)', text: 'Checkboxes - First - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__key', text: 'Checkboxes - First'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector 'h2:nth-of-type(2)', text: 'Checkboxes - Second - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__key', text: 'Checkboxes - Second'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__value', text: 'Two'
+
+    expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Checkboxes - Third - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Checkboxes - Third'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'Three - summary version'
+
+    expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Checkboxes - Fourth - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Checkboxes - Fourth'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'Four - summary version'
+
     click_on 'Accept and send application'
 
     # confirmation
     expect(page).to have_selector 'h1.govuk-panel__title', text: 'Checkboxes - Confirmation'
+  end
+
+  def back
+    find('.govuk-back-link').click
   end
 
   def continue

--- a/tests/spec/date_spec.rb
+++ b/tests/spec/date_spec.rb
@@ -67,7 +67,13 @@ describe 'Date' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Date - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: '4 April 1973'
 
-    # Change
+    ########################################
+    #                                      #
+    #   CHANGE                             #
+    #                                      #
+    ########################################
+
+    # change
     find('.govuk-summary-list:nth-of-type(4) .govuk-summary-list__actions a').click
 
     # date
@@ -83,6 +89,47 @@ describe 'Date' do
     expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Date - Fourth - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Date - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: '1 January 1970'
+
+    ########################################
+    #                                      #
+    #   BACK                               #
+    #                                      #
+    ########################################
+
+    # back
+    find('.govuk-back-link').click
+
+    # fourth
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Fourth - section heading'
+    find('.govuk-back-link').click
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Third - section heading'
+    find('.govuk-back-link').click
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Second - section heading'
+    find('.govuk-back-link').click
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Date - First - section heading'
+    continue
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Second - section heading'
+    continue
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Third - section heading'
+    continue
+
+    # fourth
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Fourth - section heading'
+    continue
+
+    # summary
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Summary - section heading'
+    expect(page).to have_selector 'h1', text: 'Summary'
 
     click_on 'Accept and send application'
 

--- a/tests/spec/date_spec.rb
+++ b/tests/spec/date_spec.rb
@@ -47,6 +47,12 @@ describe 'Date' do
     fill_in 'COMPOSITE--date-fourth-year', with: "1973"
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
@@ -86,6 +92,13 @@ describe 'Date' do
     fill_in 'COMPOSITE--date-fourth-year', with: "1970"
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
+    # summary
     expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Date - Fourth - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Date - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: '1 January 1970'
@@ -97,44 +110,137 @@ describe 'Date' do
     ########################################
 
     # back
-    find('.govuk-back-link').click
+    back
 
     # fourth
     expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Fourth - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1', text: 'Date - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Date - Fourth - hint text'
+
+    expect(find_field('COMPOSITE--date-fourth-day').value).to eq '1'
+    expect(find_field('COMPOSITE--date-fourth-month').value).to eq '1'
+    expect(find_field('COMPOSITE--date-fourth-year').value).to eq '1970'
+    back
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Third - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1', text: 'Date - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Date - Third - hint text'
+
+    expect(find_field('COMPOSITE--auto_name_3-day').value).to eq '3'
+    expect(find_field('COMPOSITE--auto_name_3-month').value).to eq '3'
+    expect(find_field('COMPOSITE--auto_name_3-year').value).to eq '1972'
+    back
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Second - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1', text: 'Date - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Date - Second - hint text'
+
+    expect(find_field('COMPOSITE--auto_name_2-day').value).to eq '2'
+    expect(find_field('COMPOSITE--auto_name_2-month').value).to eq '2'
+    expect(find_field('COMPOSITE--auto_name_2-year').value).to eq '1971'
+    back
 
     # first
     expect(page).to have_selector '.fb-sectionHeading', text: 'Date - First - section heading'
+    expect(page).to have_selector 'h1', text: 'Date - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Date - First - hint text'
+
+    expect(find_field('COMPOSITE--auto_name_1-day').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_1-month').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_1-year').value).to eq '1970'
+    back
+
+    ########################################
+    #                                      #
+    #   START                              #
+    #                                      #
+    ########################################
+
+    # start
+    click_on 'Start'
+
+    ########################################
+    #                                      #
+    #   FORWARD                            #
+    #                                      #
+    ########################################
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Date - First - section heading'
+    expect(page).to have_selector 'h1', text: 'Date - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Date - First - hint text'
+
+    expect(find_field('COMPOSITE--auto_name_1-day').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_1-month').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_1-year').value).to eq '1970'
     continue
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Second - section heading'
+    expect(page).to have_selector 'h1', text: 'Date - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Date - Second - hint text'
+
+    expect(find_field('COMPOSITE--auto_name_2-day').value).to eq '2'
+    expect(find_field('COMPOSITE--auto_name_2-month').value).to eq '2'
+    expect(find_field('COMPOSITE--auto_name_2-year').value).to eq '1971'
     continue
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Third - section heading'
+    expect(page).to have_selector 'h1', text: 'Date - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Date - Third - hint text'
+
+    expect(find_field('COMPOSITE--auto_name_3-day').value).to eq '3'
+    expect(find_field('COMPOSITE--auto_name_3-month').value).to eq '3'
+    expect(find_field('COMPOSITE--auto_name_3-year').value).to eq '1972'
     continue
 
     # fourth
     expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Fourth - section heading'
+    expect(page).to have_selector 'h1', text: 'Date - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Date - Fourth - hint text'
+
+    expect(find_field('COMPOSITE--date-fourth-day').value).to eq '1'
+    expect(find_field('COMPOSITE--date-fourth-month').value).to eq '1'
+    expect(find_field('COMPOSITE--date-fourth-year').value).to eq '1970'
     continue
+
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
 
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Date - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
 
+    expect(page).to have_selector 'h2:nth-of-type(1)', text: 'Date - First - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__key', text: 'Date - First'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__value', text: '1 January 1970'
+
+    expect(page).to have_selector 'h2:nth-of-type(2)', text: 'Date - Second - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__key', text: 'Date - Second'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__value', text: '2 February 1971'
+
+    expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Date - Third - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Date - Third'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: '3 March 1972'
+
+    expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Date - Fourth - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Date - Fourth'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: '1 January 1970'
+
     click_on 'Accept and send application'
 
     # confirmation
     expect(page).to have_selector 'h1.govuk-panel__title', text: 'Date - Confirmation'
+  end
+
+  def back
+    find('.govuk-back-link').click
   end
 
   def continue

--- a/tests/spec/email_spec.rb
+++ b/tests/spec/email_spec.rb
@@ -30,6 +30,12 @@ describe 'Email' do
     fill_in 'email-third', with: "form-builder-developers@digital.justice.gov.uk"
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Email - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
@@ -63,6 +69,12 @@ describe 'Email' do
     fill_in 'email-third', with: "form-builder-team@digital.justice.gov.uk"
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Email - Third - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Email - Third'
@@ -75,36 +87,101 @@ describe 'Email' do
     ########################################
 
     # back
-    find('.govuk-back-link').click
+    back
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Email - Third - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Email - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Email - Third - hint text'
+
+    expect(find_field('email-third').value).to eq 'form-builder-team@digital.justice.gov.uk'
+    back
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Email - Second - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Email - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Email - Second - hint text'
+
+    expect(find_field('page_email-second--email_auto_name_2').value).to eq 'form-builder-developers@digital.justice.gov.uk'
+    back
 
     # first
     expect(page).to have_selector '.fb-sectionHeading', text: 'Email - First - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Email - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Email - First - hint text'
+
+    expect(find_field('page_email-first--email_auto_name_1').value).to eq 'form-builder-developers@digital.justice.gov.uk'
+    back
+
+    ########################################
+    #                                      #
+    #   START                              #
+    #                                      #
+    ########################################
+
+    # start
+    click_on 'Start'
+
+    ########################################
+    #                                      #
+    #   FORWARD                            #
+    #                                      #
+    ########################################
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Email - First - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Email - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Email - First - hint text'
+
+    expect(find_field('page_email-first--email_auto_name_1').value).to eq 'form-builder-developers@digital.justice.gov.uk'
     continue
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Email - Second - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Email - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Email - Second - hint text'
+
+    expect(find_field('page_email-second--email_auto_name_2').value).to eq 'form-builder-developers@digital.justice.gov.uk'
     continue
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Email - Third - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Email - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Email - Third - hint text'
+
+    expect(find_field('email-third').value).to eq 'form-builder-team@digital.justice.gov.uk'
     continue
+
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
 
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Email - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
 
+    expect(page).to have_selector 'h2:nth-of-type(1)', text: 'Email - First - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__key', text: 'Email - First'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__value', text: 'form-builder-developers@digital.justice.gov.uk'
+
+    expect(page).to have_selector 'h2:nth-of-type(2)', text: 'Email - Second - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__key', text: 'Email - Second'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__value', text: 'form-builder-developers@digital.justice.gov.uk'
+
+    expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Email - Third - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Email - Third'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'form-builder-team@digital.justice.gov.uk'
+
     click_on 'Accept and send application'
 
     # confirmation
     expect(page).to have_selector 'h1.govuk-panel__title', text: 'Email - Confirmation'
+  end
+
+  def back
+    find('.govuk-back-link').click
   end
 
   def continue

--- a/tests/spec/email_spec.rb
+++ b/tests/spec/email_spec.rb
@@ -46,7 +46,13 @@ describe 'Email' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Email - Third'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'form-builder-developers@digital.justice.gov.uk'
 
-    # Change
+    ########################################
+    #                                      #
+    #   CHANGE                             #
+    #                                      #
+    ########################################
+
+    # change
     find('.govuk-summary-list:nth-of-type(3) .govuk-summary-list__actions a').click
 
     # email
@@ -61,6 +67,39 @@ describe 'Email' do
     expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Email - Third - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Email - Third'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'form-builder-team@digital.justice.gov.uk'
+
+    ########################################
+    #                                      #
+    #   BACK                               #
+    #                                      #
+    ########################################
+
+    # back
+    find('.govuk-back-link').click
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Email - Third - section heading'
+    find('.govuk-back-link').click
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Email - Second - section heading'
+    find('.govuk-back-link').click
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Email - First - section heading'
+    continue
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Email - Second - section heading'
+    continue
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Email - Third - section heading'
+    continue
+
+    # summary
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Email - Summary - section heading'
+    expect(page).to have_selector 'h1', text: 'Summary'
 
     click_on 'Accept and send application'
 

--- a/tests/spec/fieldset_spec.rb
+++ b/tests/spec/fieldset_spec.rb
@@ -386,7 +386,13 @@ describe 'Fieldset' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__key', text: 'Upload'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__value', text: '4.jpg (1.34MB)'
 
-    # Change
+    ########################################
+    #                                      #
+    #   CHANGE                             #
+    #                                      #
+    ########################################
+
+    # change
     find('.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__actions a').click
 
     # autocomplete
@@ -484,6 +490,87 @@ describe 'Fieldset' do
 
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__key', text: 'Upload'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__value', text: '1.jpg (1.34MB)'
+
+    ########################################
+    #                                      #
+    #   BACK                               #
+    #                                      #
+    ########################################
+
+    # back
+    find('.govuk-back-link').click
+
+    # fourth
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Fourth - section heading'
+    find('.govuk-back-link').click
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Third - section heading'
+    find('.govuk-back-link').click
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Second - section heading'
+    find('.govuk-back-link').click
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - First - section heading'
+
+    # upload
+    attach_file('auto_name__13[1]', 'spec/fixtures/files/1.jpg')
+    continue
+
+    expect(page).to have_selector 'h1', text: 'Fieldset - First - Check'
+    expect(page).to have_selector '.fb-upload-descriptions', text: '1.jpg, 1.34MB'
+
+    # radios
+    choose 'decision', option: 'accept', visible: false
+    continue
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Second - section heading'
+
+    # upload
+    attach_file('auto_name__25[1]', 'spec/fixtures/files/2.jpg')
+    continue
+
+    expect(page).to have_selector 'h1', text: 'Fieldset - Second - Check'
+    expect(page).to have_selector '.fb-upload-descriptions', text: '2.jpg, 1.34MB'
+
+    # radios
+    choose 'decision', option: 'accept', visible: false
+    continue
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Third - section heading'
+
+    # upload
+    attach_file('auto_name__37[1]', 'spec/fixtures/files/3.jpg')
+    continue
+
+    expect(page).to have_selector 'h1', text: 'Fieldset - Third - Check'
+    expect(page).to have_selector '.fb-upload-descriptions', text: '3.jpg, 1.34MB'
+
+    # radios
+    choose 'decision', option: 'accept', visible: false
+    continue
+
+    # fourth
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Fourth - section heading'
+
+    # upload
+    attach_file('auto_name__49[1]', 'spec/fixtures/files/4.jpg')
+    continue
+
+    expect(page).to have_selector 'h1', text: 'Fieldset - Fourth - Check'
+    expect(page).to have_selector '.fb-upload-descriptions', text: '4.jpg, 1.34MB'
+
+    # radios
+    choose 'decision', option: 'accept', visible: false
+    continue
+
+    # summary
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Summary - section heading'
+    expect(page).to have_selector 'h1', text: 'Summary'
 
     click_on 'Accept and send application'
 

--- a/tests/spec/fieldset_spec.rb
+++ b/tests/spec/fieldset_spec.rb
@@ -254,6 +254,12 @@ describe 'Fieldset' do
     choose 'decision', option: 'accept', visible: false
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
@@ -459,6 +465,13 @@ describe 'Fieldset' do
     choose 'decision', option: 'accept', visible: false
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
+    # summary
     expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Fieldset - Fourth - section heading'
 
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__key', text: 'Autocomplete'
@@ -498,22 +511,204 @@ describe 'Fieldset' do
     ########################################
 
     # back
-    find('.govuk-back-link').click
+    back
 
     # fourth
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Fourth - section heading'
-    find('.govuk-back-link').click
+
+    # autocomplete
+    # expect(find_field('page_fieldset-fourth--fieldset--autocomplete_auto_name_37').value).to eq 'One'
+
+    # checkboxes
+    expect(page).to have_field('auto_name__38', visible: false, checked: true)
+    expect(page).to have_field('auto_name__39', visible: false, checked: true)
+    expect(page).to have_field('auto_name__40', visible: false, checked: true)
+    expect(page).to have_field('auto_name__41', visible: false, checked: true)
+
+    # date
+    expect(find_field('COMPOSITE--auto_name_42-day').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_42-month').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_42-year').value).to eq '1970'
+
+    # email
+    expect(find_field('page_fieldset-fourth--fieldset--email_auto_name_43').value).to eq 'form-builder-team@digital.justice.gov.uk'
+
+    # number
+    expect(find_field('page_fieldset-fourth--fieldset--number_auto_name_44').value).to eq '1'
+
+    # radios
+    expect(find_field('auto_name__45', checked: true, visible: false).value).to eq '1'
+
+    # select
+    expect(page).to have_select 'page_fieldset-fourth--fieldset--select_auto_name_46', selected: 'One'
+
+    # text
+    expect(find_field('page_fieldset-fourth--fieldset--text_auto_name_47').value).to eq 'One'
+
+    # textarea
+    expect(find_field('page_fieldset-fourth--fieldset--textarea_auto_name_48').value).to eq 'One'
+
+    back
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Third - section heading'
-    find('.govuk-back-link').click
+
+    # autocomplete
+    # expect(find_field('page_fieldset-third--fieldset--autocomplete_auto_name_25').value).to eq 'Three'
+
+    # checkboxes
+    expect(page).to have_field('auto_name__26', visible: false, checked: false)
+    expect(page).to have_field('auto_name__27', visible: false, checked: false)
+    expect(page).to have_field('auto_name__28', visible: false, checked: true)
+    expect(page).to have_field('auto_name__29', visible: false, checked: false)
+
+    # date
+    expect(find_field('COMPOSITE--auto_name_30-day').value).to eq '3'
+    expect(find_field('COMPOSITE--auto_name_30-month').value).to eq '3'
+    expect(find_field('COMPOSITE--auto_name_30-year').value).to eq '1972'
+
+    # email
+    expect(find_field('page_fieldset-third--fieldset--email_auto_name_31').value).to eq 'form-builder-developers@digital.justice.gov.uk'
+
+    # number
+    expect(find_field('page_fieldset-third--fieldset--number_auto_name_32').value).to eq '3'
+
+    # radios
+    expect(find_field('auto_name__33', checked: true, visible: false).value).to eq '3'
+
+    # select
+    expect(page).to have_select 'page_fieldset-third--fieldset--select_auto_name_34', selected: 'Three'
+
+    # text
+    expect(find_field('page_fieldset-third--fieldset--text_auto_name_35').value).to eq 'Three'
+
+    # textarea
+    expect(find_field('page_fieldset-third--fieldset--textarea_auto_name_36').value).to eq 'Three'
+
+    back
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Second - section heading'
-    find('.govuk-back-link').click
+
+    # autocomplete
+    # expect(find_field('page_fieldset-second--fieldset--autocomplete_auto_name_13').value).to eq 'Two'
+
+    # checkboxes
+    expect(page).to have_field('auto_name__14', visible: false, checked: false)
+    expect(page).to have_field('auto_name__15', visible: false, checked: true)
+    expect(page).to have_field('auto_name__16', visible: false, checked: false)
+    expect(page).to have_field('auto_name__17', visible: false, checked: false)
+
+    # date
+    expect(find_field('COMPOSITE--auto_name_18-day').value).to eq '2'
+    expect(find_field('COMPOSITE--auto_name_18-month').value).to eq '2'
+    expect(find_field('COMPOSITE--auto_name_18-year').value).to eq '1971'
+
+    # email
+    expect(find_field('page_fieldset-second--fieldset--email_auto_name_19').value).to eq 'form-builder-developers@digital.justice.gov.uk'
+
+    # number
+    expect(find_field('page_fieldset-second--fieldset--number_auto_name_20').value).to eq '2'
+
+    # radios
+    expect(find_field('auto_name__21', checked: true, visible: false).value).to eq '2'
+
+    # select
+    expect(page).to have_select 'page_fieldset-second--fieldset--select_auto_name_22', selected: 'Two'
+
+    # text
+    expect(find_field('page_fieldset-second--fieldset--text_auto_name_23').value).to eq 'Two'
+
+    # textarea
+    expect(find_field('page_fieldset-second--fieldset--textarea_auto_name_24').value).to eq 'Two'
+
+    back
 
     # first
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - First - section heading'
+
+    # autocomplete
+    # expect(find_field('page_fieldset-first--fieldset--autocomplete_auto_name_1').value).to eq 'One'
+
+    # checkboxes
+    expect(page).to have_field('auto_name__2', visible: false, checked: true)
+    expect(page).to have_field('auto_name__3', visible: false, checked: false)
+    expect(page).to have_field('auto_name__4', visible: false, checked: false)
+    expect(page).to have_field('auto_name__5', visible: false, checked: false)
+
+    # date
+    expect(find_field('COMPOSITE--auto_name_6-day').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_6-month').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_6-year').value).to eq '1970'
+
+    # email
+    expect(find_field('page_fieldset-first--fieldset--email_auto_name_7').value).to eq 'form-builder-developers@digital.justice.gov.uk'
+
+    # number
+    expect(find_field('page_fieldset-first--fieldset--number_auto_name_8').value).to eq '1'
+
+    # radios
+    expect(find_field('auto_name__9', checked: true, visible: false).value).to eq '1'
+
+    # select
+    expect(page).to have_select 'page_fieldset-first--fieldset--select_auto_name_10', selected: 'One'
+
+    # text
+    expect(find_field('page_fieldset-first--fieldset--text_auto_name_11').value).to eq 'One'
+
+    # textarea
+    expect(find_field('page_fieldset-first--fieldset--textarea_auto_name_12').value).to eq 'One'
+
+    back
+
+    ########################################
+    #                                      #
+    #   START                              #
+    #                                      #
+    ########################################
+
+    click_on 'Start'
+
+    ########################################
+    #                                      #
+    #   FORWARD                            #
+    #                                      #
+    ########################################
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - First - section heading'
+
+    # autocomplete
+    # expect(find_field('page_fieldset-first--fieldset--autocomplete_auto_name_1').value).to eq 'One'
+
+    # checkboxes
+    expect(page).to have_field('auto_name__2', visible: false, checked: true)
+    expect(page).to have_field('auto_name__3', visible: false, checked: false)
+    expect(page).to have_field('auto_name__4', visible: false, checked: false)
+    expect(page).to have_field('auto_name__5', visible: false, checked: false)
+
+    # date
+    expect(find_field('COMPOSITE--auto_name_6-day').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_6-month').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_6-year').value).to eq '1970'
+
+    # email
+    expect(find_field('page_fieldset-first--fieldset--email_auto_name_7').value).to eq 'form-builder-developers@digital.justice.gov.uk'
+
+    # number
+    expect(find_field('page_fieldset-first--fieldset--number_auto_name_8').value).to eq '1'
+
+    # radios
+    expect(find_field('auto_name__9', checked: true, visible: false).value).to eq '1'
+
+    # select
+    expect(page).to have_select 'page_fieldset-first--fieldset--select_auto_name_10', selected: 'One'
+
+    # text
+    expect(find_field('page_fieldset-first--fieldset--text_auto_name_11').value).to eq 'One'
+
+    # textarea
+    expect(find_field('page_fieldset-first--fieldset--textarea_auto_name_12').value).to eq 'One'
 
     # upload
     attach_file('auto_name__13[1]', 'spec/fixtures/files/1.jpg')
@@ -529,6 +724,38 @@ describe 'Fieldset' do
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Second - section heading'
 
+    # autocomplete
+    # expect(find_field('page_fieldset-second--fieldset--autocomplete_auto_name_13').value).to eq 'Two'
+
+    # checkboxes
+    expect(page).to have_field('auto_name__14', visible: false, checked: false)
+    expect(page).to have_field('auto_name__15', visible: false, checked: true)
+    expect(page).to have_field('auto_name__16', visible: false, checked: false)
+    expect(page).to have_field('auto_name__17', visible: false, checked: false)
+
+    # date
+    expect(find_field('COMPOSITE--auto_name_18-day').value).to eq '2'
+    expect(find_field('COMPOSITE--auto_name_18-month').value).to eq '2'
+    expect(find_field('COMPOSITE--auto_name_18-year').value).to eq '1971'
+
+    # email
+    expect(find_field('page_fieldset-second--fieldset--email_auto_name_19').value).to eq 'form-builder-developers@digital.justice.gov.uk'
+
+    # number
+    expect(find_field('page_fieldset-second--fieldset--number_auto_name_20').value).to eq '2'
+
+    # radios
+    expect(find_field('auto_name__21', checked: true, visible: false).value).to eq '2'
+
+    # select
+    expect(page).to have_select 'page_fieldset-second--fieldset--select_auto_name_22', selected: 'Two'
+
+    # text
+    expect(find_field('page_fieldset-second--fieldset--text_auto_name_23').value).to eq 'Two'
+
+    # textarea
+    expect(find_field('page_fieldset-second--fieldset--textarea_auto_name_24').value).to eq 'Two'
+
     # upload
     attach_file('auto_name__25[1]', 'spec/fixtures/files/2.jpg')
     continue
@@ -542,6 +769,38 @@ describe 'Fieldset' do
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Third - section heading'
+
+    # autocomplete
+    # expect(find_field('page_fieldset-third--fieldset--autocomplete_auto_name_25').value).to eq 'Three'
+
+    # checkboxes
+    expect(page).to have_field('auto_name__26', visible: false, checked: false)
+    expect(page).to have_field('auto_name__27', visible: false, checked: false)
+    expect(page).to have_field('auto_name__28', visible: false, checked: true)
+    expect(page).to have_field('auto_name__29', visible: false, checked: false)
+
+    # date
+    expect(find_field('COMPOSITE--auto_name_30-day').value).to eq '3'
+    expect(find_field('COMPOSITE--auto_name_30-month').value).to eq '3'
+    expect(find_field('COMPOSITE--auto_name_30-year').value).to eq '1972'
+
+    # email
+    expect(find_field('page_fieldset-third--fieldset--email_auto_name_31').value).to eq 'form-builder-developers@digital.justice.gov.uk'
+
+    # number
+    expect(find_field('page_fieldset-third--fieldset--number_auto_name_32').value).to eq '3'
+
+    # radios
+    expect(find_field('auto_name__33', checked: true, visible: false).value).to eq '3'
+
+    # select
+    expect(page).to have_select 'page_fieldset-third--fieldset--select_auto_name_34', selected: 'Three'
+
+    # text
+    expect(find_field('page_fieldset-third--fieldset--text_auto_name_35').value).to eq 'Three'
+
+    # textarea
+    expect(find_field('page_fieldset-third--fieldset--textarea_auto_name_36').value).to eq 'Three'
 
     # upload
     attach_file('auto_name__37[1]', 'spec/fixtures/files/3.jpg')
@@ -557,6 +816,38 @@ describe 'Fieldset' do
     # fourth
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Fourth - section heading'
 
+    # autocomplete
+    # expect(find_field('page_fieldset-fourth--fieldset--autocomplete_auto_name_37').value).to eq 'One'
+
+    # checkboxes
+    expect(page).to have_field('auto_name__38', visible: false, checked: true)
+    expect(page).to have_field('auto_name__39', visible: false, checked: true)
+    expect(page).to have_field('auto_name__40', visible: false, checked: true)
+    expect(page).to have_field('auto_name__41', visible: false, checked: true)
+
+    # date
+    expect(find_field('COMPOSITE--auto_name_42-day').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_42-month').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_42-year').value).to eq '1970'
+
+    # email
+    expect(find_field('page_fieldset-fourth--fieldset--email_auto_name_43').value).to eq 'form-builder-team@digital.justice.gov.uk'
+
+    # number
+    expect(find_field('page_fieldset-fourth--fieldset--number_auto_name_44').value).to eq '1'
+
+    # radios
+    expect(find_field('auto_name__45', checked: true, visible: false).value).to eq '1'
+
+    # select
+    expect(page).to have_select 'page_fieldset-fourth--fieldset--select_auto_name_46', selected: 'One'
+
+    # text
+    expect(find_field('page_fieldset-fourth--fieldset--text_auto_name_47').value).to eq 'One'
+
+    # textarea
+    expect(find_field('page_fieldset-fourth--fieldset--textarea_auto_name_48').value).to eq 'One'
+
     # upload
     attach_file('auto_name__49[1]', 'spec/fixtures/files/4.jpg')
     continue
@@ -568,14 +859,152 @@ describe 'Fieldset' do
     choose 'decision', option: 'accept', visible: false
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
+
+    expect(page).to have_selector 'h2:nth-of-type(1)', text: 'Fieldset - First - section heading'
+
+    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__key', text: 'Autocomplete'
+    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__key', text: 'Checkboxes'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__key', text: 'Date'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__value', text: '1 January 1970'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(4) .govuk-summary-list__key', text: 'Email'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(4) .govuk-summary-list__value', text: 'form-builder-developers@digital.justice.gov.uk'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(5) .govuk-summary-list__key', text: 'Number'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(5) .govuk-summary-list__value', text: '1'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(6) .govuk-summary-list__key', text: 'Radios'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(6) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(7) .govuk-summary-list__key', text: 'Select'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(7) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(8) .govuk-summary-list__key', text: 'Text'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(8) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(9) .govuk-summary-list__key', text: 'Textarea'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(9) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__key', text: 'Upload'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__value', text: '1.jpg (1.34MB)'
+
+    expect(page).to have_selector 'h2:nth-of-type(2)', text: 'Fieldset - Second - section heading'
+
+    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__key', text: 'Autocomplete'
+    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__value', text: 'Two'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__key', text: 'Checkboxes'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__value', text: 'Two'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__key', text: 'Date'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__value', text: '2 February 1971'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(4) .govuk-summary-list__key', text: 'Email'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(4) .govuk-summary-list__value', text: 'form-builder-developers@digital.justice.gov.uk'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(5) .govuk-summary-list__key', text: 'Number'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(5) .govuk-summary-list__value', text: '2'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(6) .govuk-summary-list__key', text: 'Radios'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(6) .govuk-summary-list__value', text: 'Two'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(7) .govuk-summary-list__key', text: 'Select'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(7) .govuk-summary-list__value', text: 'Two'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(8) .govuk-summary-list__key', text: 'Text'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(8) .govuk-summary-list__value', text: 'Two'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(9) .govuk-summary-list__key', text: 'Textarea'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(9) .govuk-summary-list__value', text: 'Two'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__key', text: 'Upload'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__value', text: '2.jpg (1.34MB)'
+
+    expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Fieldset - Third - section heading'
+
+    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__key', text: 'Autocomplete'
+    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__value', text: 'Three'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__key', text: 'Checkboxes'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__value', text: 'Three - summary version'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__key', text: 'Date'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__value', text: '3 March 1972'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(4) .govuk-summary-list__key', text: 'Email'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(4) .govuk-summary-list__value', text: 'form-builder-developers@digital.justice.gov.uk'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(5) .govuk-summary-list__key', text: 'Number'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(5) .govuk-summary-list__value', text: '3'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(6) .govuk-summary-list__key', text: 'Radios'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(6) .govuk-summary-list__value', text: 'Three - summary version'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(7) .govuk-summary-list__key', text: 'Select'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(7) .govuk-summary-list__value', text: 'Three'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(8) .govuk-summary-list__key', text: 'Text'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(8) .govuk-summary-list__value', text: 'Three'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(9) .govuk-summary-list__key', text: 'Textarea'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(9) .govuk-summary-list__value', text: 'Three'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__key', text: 'Upload'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__value', text: '3.jpg (1.34MB)'
+
+    expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Fieldset - Fourth - section heading'
+
+    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__key', text: 'Autocomplete'
+    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__key', text: 'Checkboxes'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__value', text: /One - summary version\s*Two - summary version\s*Three - summary version\s*Four - summary version/
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__key', text: 'Date'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__value', text: '1 January 1970'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(4) .govuk-summary-list__key', text: 'Email'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(4) .govuk-summary-list__value', text: 'form-builder-team@digital.justice.gov.uk'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(5) .govuk-summary-list__key', text: 'Number'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(5) .govuk-summary-list__value', text: '1'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(6) .govuk-summary-list__key', text: 'Radios'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(6) .govuk-summary-list__value', text: 'One - summary version'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(7) .govuk-summary-list__key', text: 'Select'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(7) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(8) .govuk-summary-list__key', text: 'Text'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(8) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(9) .govuk-summary-list__key', text: 'Textarea'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(9) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__key', text: 'Upload'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(10) .govuk-summary-list__value', text: '4.jpg (1.34MB)'
 
     click_on 'Accept and send application'
 
     # confirmation
     expect(page).to have_selector 'h1.govuk-panel__title', text: 'Fieldset - Confirmation'
+  end
+
+  def back
+    find('.govuk-back-link').click
   end
 
   def continue

--- a/tests/spec/fieldset_spec.rb
+++ b/tests/spec/fieldset_spec.rb
@@ -74,52 +74,52 @@ describe 'Fieldset' do
 
     expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - Second - hint text'
 
-    fill_in 'page_fieldset-second--fieldset--autocomplete_auto_name_13', with: "Two\n" # the new line 'presses enter' on the selected option
+    fill_in 'page_fieldset-second--fieldset--autocomplete_auto_name_14', with: "Two\n" # the new line 'presses enter' on the selected option
 
     # checkboxes
     expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Second - hint text'
 
-    check 'auto_name__15', visible: false
+    check 'auto_name__16', visible: false
 
     # date
     expect(page).to have_selector '.govuk-hint', text: 'Date - Second - hint text'
 
-    fill_in 'COMPOSITE--auto_name_18-day', with: "2"
-    fill_in 'COMPOSITE--auto_name_18-month', with: "2"
-    fill_in 'COMPOSITE--auto_name_18-year', with: "1971"
+    fill_in 'COMPOSITE--auto_name_19-day', with: "2"
+    fill_in 'COMPOSITE--auto_name_19-month', with: "2"
+    fill_in 'COMPOSITE--auto_name_19-year', with: "1971"
 
     # email
     expect(page).to have_selector '.govuk-hint', text: 'Email - Second - hint text'
 
-    fill_in 'page_fieldset-second--fieldset--email_auto_name_19', with: "form-builder-developers@digital.justice.gov.uk"
+    fill_in 'page_fieldset-second--fieldset--email_auto_name_20', with: "form-builder-developers@digital.justice.gov.uk"
 
     # number
     expect(page).to have_selector '.govuk-hint', text: 'Number - Second - hint text'
 
-    fill_in 'page_fieldset-second--fieldset--number_auto_name_20', with: "2"
+    fill_in 'page_fieldset-second--fieldset--number_auto_name_21', with: "2"
 
     # radios
     expect(page).to have_selector '.govuk-hint', text: 'Radios - Second - hint text'
 
-    choose 'auto_name__21', option: '2', visible: false
+    choose 'auto_name__22', option: '2', visible: false
 
     # select
     expect(page).to have_selector '.govuk-hint', text: 'Select - Second - hint text'
 
-    select 'Two', from: 'page_fieldset-second--fieldset--select_auto_name_22'
+    select 'Two', from: 'page_fieldset-second--fieldset--select_auto_name_23'
 
     # text
     expect(page).to have_selector '.govuk-hint', text: 'Text - Second - hint text'
 
-    fill_in 'page_fieldset-second--fieldset--text_auto_name_23', with: "Two"
+    fill_in 'page_fieldset-second--fieldset--text_auto_name_24', with: "Two"
 
     # textarea
     expect(page).to have_selector '.govuk-hint', text: 'Textarea - Second - hint text'
 
-    fill_in 'page_fieldset-second--fieldset--textarea_auto_name_24', with: "Two"
+    fill_in 'page_fieldset-second--fieldset--textarea_auto_name_25', with: "Two"
 
     # upload
-    attach_file('auto_name__25[1]', 'spec/fixtures/files/2.jpg')
+    attach_file('auto_name__26[1]', 'spec/fixtures/files/2.jpg')
 
     continue
 
@@ -136,52 +136,52 @@ describe 'Fieldset' do
 
     expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - Third - hint text'
 
-    fill_in 'page_fieldset-third--fieldset--autocomplete_auto_name_25', with: "Three\n" # the new line 'presses enter' on the selected option
+    fill_in 'page_fieldset-third--fieldset--autocomplete_auto_name_27', with: "Three\n" # the new line 'presses enter' on the selected option
 
     # checkboxes
     expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Third - hint text'
 
-    check 'auto_name__28', visible: false
+    check 'auto_name__30', visible: false
 
     # date
     expect(page).to have_selector '.govuk-hint', text: 'Date - Third - hint text'
 
-    fill_in 'COMPOSITE--auto_name_30-day', with: "3"
-    fill_in 'COMPOSITE--auto_name_30-month', with: "3"
-    fill_in 'COMPOSITE--auto_name_30-year', with: "1972"
+    fill_in 'COMPOSITE--auto_name_32-day', with: "3"
+    fill_in 'COMPOSITE--auto_name_32-month', with: "3"
+    fill_in 'COMPOSITE--auto_name_32-year', with: "1972"
 
     # email
     expect(page).to have_selector '.govuk-hint', text: 'Email - Third - hint text'
 
-    fill_in 'page_fieldset-third--fieldset--email_auto_name_31', with: "form-builder-developers@digital.justice.gov.uk"
+    fill_in 'page_fieldset-third--fieldset--email_auto_name_33', with: "form-builder-developers@digital.justice.gov.uk"
 
     # number
     expect(page).to have_selector '.govuk-hint', text: 'Number - Third - hint text'
 
-    fill_in 'page_fieldset-third--fieldset--number_auto_name_32', with: "3"
+    fill_in 'page_fieldset-third--fieldset--number_auto_name_34', with: "3"
 
     # radios
     expect(page).to have_selector '.govuk-hint', text: 'Radios - Third - hint text'
 
-    choose 'auto_name__33', option: '3', visible: false
+    choose 'auto_name__35', option: '3', visible: false
 
     # select
     expect(page).to have_selector '.govuk-hint', text: 'Select - Third - hint text'
 
-    select 'Three', from: 'page_fieldset-third--fieldset--select_auto_name_34'
+    select 'Three', from: 'page_fieldset-third--fieldset--select_auto_name_36'
 
     # text
     expect(page).to have_selector '.govuk-hint', text: 'Text - Third - hint text'
 
-    fill_in 'page_fieldset-third--fieldset--text_auto_name_35', with: "Three"
+    fill_in 'page_fieldset-third--fieldset--text_auto_name_37', with: "Three"
 
     # textarea
     expect(page).to have_selector '.govuk-hint', text: 'Textarea - Third - hint text'
 
-    fill_in 'page_fieldset-third--fieldset--textarea_auto_name_36', with: "Three"
+    fill_in 'page_fieldset-third--fieldset--textarea_auto_name_38', with: "Three"
 
     # upload
-    attach_file('auto_name__37[1]', 'spec/fixtures/files/3.jpg')
+    attach_file('auto_name__39[1]', 'spec/fixtures/files/3.jpg')
 
     continue
 
@@ -198,52 +198,52 @@ describe 'Fieldset' do
 
     expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - Fourth - hint text'
 
-    fill_in 'page_fieldset-fourth--fieldset--autocomplete_auto_name_37', with: "Four\n" # the new line 'presses enter' on the selected option
+    fill_in 'page_fieldset-fourth--fieldset--autocomplete_auto_name_40', with: "Four\n" # the new line 'presses enter' on the selected option
 
     # checkboxes
     expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Fourth - hint text'
 
-    check 'auto_name__41', visible: false
+    check 'auto_name__44', visible: false
 
     # date
     expect(page).to have_selector '.govuk-hint', text: 'Date - Fourth - hint text'
 
-    fill_in 'COMPOSITE--auto_name_42-day', with: "4"
-    fill_in 'COMPOSITE--auto_name_42-month', with: "4"
-    fill_in 'COMPOSITE--auto_name_42-year', with: "1973"
+    fill_in 'COMPOSITE--auto_name_45-day', with: "4"
+    fill_in 'COMPOSITE--auto_name_45-month', with: "4"
+    fill_in 'COMPOSITE--auto_name_45-year', with: "1973"
 
     # email
     expect(page).to have_selector '.govuk-hint', text: 'Email - Fourth - hint text'
 
-    fill_in 'page_fieldset-fourth--fieldset--email_auto_name_43', with: "form-builder-developers@digital.justice.gov.uk"
+    fill_in 'page_fieldset-fourth--fieldset--email_auto_name_46', with: "form-builder-developers@digital.justice.gov.uk"
 
     # number
     expect(page).to have_selector '.govuk-hint', text: 'Number - Fourth - hint text'
 
-    fill_in 'page_fieldset-fourth--fieldset--number_auto_name_44', with: "4"
+    fill_in 'page_fieldset-fourth--fieldset--number_auto_name_47', with: "4"
 
     # radios
     expect(page).to have_selector '.govuk-hint', text: 'Radios - Fourth - hint text'
 
-    choose 'auto_name__45', option: '4', visible: false
+    choose 'auto_name__48', option: '4', visible: false
 
     # select
     expect(page).to have_selector '.govuk-hint', text: 'Select - Fourth - hint text'
 
-    select 'Four', from: 'page_fieldset-fourth--fieldset--select_auto_name_46'
+    select 'Four', from: 'page_fieldset-fourth--fieldset--select_auto_name_49'
 
     # text
     expect(page).to have_selector '.govuk-hint', text: 'Text - Fourth - hint text'
 
-    fill_in 'page_fieldset-fourth--fieldset--text_auto_name_47', with: "Four"
+    fill_in 'page_fieldset-fourth--fieldset--text_auto_name_50', with: "Four"
 
     # textarea
     expect(page).to have_selector '.govuk-hint', text: 'Textarea - Fourth - hint text'
 
-    fill_in 'page_fieldset-fourth--fieldset--textarea_auto_name_48', with: "Four"
+    fill_in 'page_fieldset-fourth--fieldset--textarea_auto_name_51', with: "Four"
 
     # upload
-    attach_file('auto_name__49[1]', 'spec/fixtures/files/4.jpg')
+    attach_file('auto_name__52[1]', 'spec/fixtures/files/4.jpg')
 
     continue
 
@@ -407,54 +407,54 @@ describe 'Fieldset' do
 
     expect(page).to have_selector '.govuk-hint', text: 'Autocomplete - Fourth - hint text'
 
-    fill_in 'page_fieldset-fourth--fieldset--autocomplete_auto_name_37', with: "One\n" # the new line 'presses enter' on the selected option
+    fill_in 'page_fieldset-fourth--fieldset--autocomplete_auto_name_40', with: "One\n" # the new line 'presses enter' on the selected option
 
     # checkboxes
     expect(page).to have_selector '.govuk-hint', text: 'Checkboxes - Fourth - hint text'
 
-    check 'auto_name__38', visible: false
-    check 'auto_name__39', visible: false
-    check 'auto_name__40', visible: false
+    check 'auto_name__41', visible: false
+    check 'auto_name__42', visible: false
+    check 'auto_name__43', visible: false
 
     # date
     expect(page).to have_selector '.govuk-hint', text: 'Date - Fourth - hint text'
 
-    fill_in 'COMPOSITE--auto_name_42-day', with: "1"
-    fill_in 'COMPOSITE--auto_name_42-month', with: "1"
-    fill_in 'COMPOSITE--auto_name_42-year', with: "1970"
+    fill_in 'COMPOSITE--auto_name_45-day', with: "1"
+    fill_in 'COMPOSITE--auto_name_45-month', with: "1"
+    fill_in 'COMPOSITE--auto_name_45-year', with: "1970"
 
     # email
     expect(page).to have_selector '.govuk-hint', text: 'Email - Fourth - hint text'
 
-    fill_in 'page_fieldset-fourth--fieldset--email_auto_name_43', with: "form-builder-team@digital.justice.gov.uk"
+    fill_in 'page_fieldset-fourth--fieldset--email_auto_name_46', with: "form-builder-team@digital.justice.gov.uk"
 
     # number
     expect(page).to have_selector '.govuk-hint', text: 'Number - Fourth - hint text'
 
-    fill_in 'page_fieldset-fourth--fieldset--number_auto_name_44', with: "1"
+    fill_in 'page_fieldset-fourth--fieldset--number_auto_name_47', with: "1"
 
     # radios
     expect(page).to have_selector '.govuk-hint', text: 'Radios - Fourth - hint text'
 
-    choose 'auto_name__45', option: '1', visible: false
+    choose 'auto_name__48', option: '1', visible: false
 
     # select
     expect(page).to have_selector '.govuk-hint', text: 'Select - Fourth - hint text'
 
-    select 'One', from: 'page_fieldset-fourth--fieldset--select_auto_name_46'
+    select 'One', from: 'page_fieldset-fourth--fieldset--select_auto_name_49'
 
     # text
     expect(page).to have_selector '.govuk-hint', text: 'Text - Fourth - hint text'
 
-    fill_in 'page_fieldset-fourth--fieldset--text_auto_name_47', with: "One"
+    fill_in 'page_fieldset-fourth--fieldset--text_auto_name_50', with: "One"
 
     # textarea
     expect(page).to have_selector '.govuk-hint', text: 'Textarea - Fourth - hint text'
 
-    fill_in 'page_fieldset-fourth--fieldset--textarea_auto_name_48', with: "One"
+    fill_in 'page_fieldset-fourth--fieldset--textarea_auto_name_51', with: "One"
 
     # upload
-    attach_file('auto_name__49[1]', 'spec/fixtures/files/1.jpg')
+    attach_file('auto_name__52[1]', 'spec/fixtures/files/1.jpg')
 
     continue
 
@@ -517,36 +517,36 @@ describe 'Fieldset' do
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Fourth - section heading'
 
     # autocomplete
-    # expect(find_field('page_fieldset-fourth--fieldset--autocomplete_auto_name_37').value).to eq 'One'
+    expect(find_field('page_fieldset-fourth--fieldset--autocomplete_auto_name_40').value).to eq 'One'
 
     # checkboxes
-    expect(page).to have_field('auto_name__38', visible: false, checked: true)
-    expect(page).to have_field('auto_name__39', visible: false, checked: true)
-    expect(page).to have_field('auto_name__40', visible: false, checked: true)
     expect(page).to have_field('auto_name__41', visible: false, checked: true)
+    expect(page).to have_field('auto_name__42', visible: false, checked: true)
+    expect(page).to have_field('auto_name__43', visible: false, checked: true)
+    expect(page).to have_field('auto_name__44', visible: false, checked: true)
 
     # date
-    expect(find_field('COMPOSITE--auto_name_42-day').value).to eq '1'
-    expect(find_field('COMPOSITE--auto_name_42-month').value).to eq '1'
-    expect(find_field('COMPOSITE--auto_name_42-year').value).to eq '1970'
+    expect(find_field('COMPOSITE--auto_name_45-day').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_45-month').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_45-year').value).to eq '1970'
 
     # email
-    expect(find_field('page_fieldset-fourth--fieldset--email_auto_name_43').value).to eq 'form-builder-team@digital.justice.gov.uk'
+    expect(find_field('page_fieldset-fourth--fieldset--email_auto_name_46').value).to eq 'form-builder-team@digital.justice.gov.uk'
 
     # number
-    expect(find_field('page_fieldset-fourth--fieldset--number_auto_name_44').value).to eq '1'
+    expect(find_field('page_fieldset-fourth--fieldset--number_auto_name_47').value).to eq '1'
 
     # radios
-    expect(find_field('auto_name__45', checked: true, visible: false).value).to eq '1'
+    expect(find_field('auto_name__48', checked: true, visible: false).value).to eq '1'
 
     # select
-    expect(page).to have_select 'page_fieldset-fourth--fieldset--select_auto_name_46', selected: 'One'
+    expect(page).to have_select 'page_fieldset-fourth--fieldset--select_auto_name_49', selected: 'One'
 
     # text
-    expect(find_field('page_fieldset-fourth--fieldset--text_auto_name_47').value).to eq 'One'
+    expect(find_field('page_fieldset-fourth--fieldset--text_auto_name_50').value).to eq 'One'
 
     # textarea
-    expect(find_field('page_fieldset-fourth--fieldset--textarea_auto_name_48').value).to eq 'One'
+    expect(find_field('page_fieldset-fourth--fieldset--textarea_auto_name_51').value).to eq 'One'
 
     back
 
@@ -554,36 +554,36 @@ describe 'Fieldset' do
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Third - section heading'
 
     # autocomplete
-    # expect(find_field('page_fieldset-third--fieldset--autocomplete_auto_name_25').value).to eq 'Three'
+    expect(find_field('page_fieldset-third--fieldset--autocomplete_auto_name_27').value).to eq 'Three'
 
     # checkboxes
-    expect(page).to have_field('auto_name__26', visible: false, checked: false)
-    expect(page).to have_field('auto_name__27', visible: false, checked: false)
-    expect(page).to have_field('auto_name__28', visible: false, checked: true)
+    expect(page).to have_field('auto_name__28', visible: false, checked: false)
     expect(page).to have_field('auto_name__29', visible: false, checked: false)
+    expect(page).to have_field('auto_name__30', visible: false, checked: true)
+    expect(page).to have_field('auto_name__31', visible: false, checked: false)
 
     # date
-    expect(find_field('COMPOSITE--auto_name_30-day').value).to eq '3'
-    expect(find_field('COMPOSITE--auto_name_30-month').value).to eq '3'
-    expect(find_field('COMPOSITE--auto_name_30-year').value).to eq '1972'
+    expect(find_field('COMPOSITE--auto_name_32-day').value).to eq '3'
+    expect(find_field('COMPOSITE--auto_name_32-month').value).to eq '3'
+    expect(find_field('COMPOSITE--auto_name_32-year').value).to eq '1972'
 
     # email
-    expect(find_field('page_fieldset-third--fieldset--email_auto_name_31').value).to eq 'form-builder-developers@digital.justice.gov.uk'
+    expect(find_field('page_fieldset-third--fieldset--email_auto_name_33').value).to eq 'form-builder-developers@digital.justice.gov.uk'
 
     # number
-    expect(find_field('page_fieldset-third--fieldset--number_auto_name_32').value).to eq '3'
+    expect(find_field('page_fieldset-third--fieldset--number_auto_name_34').value).to eq '3'
 
     # radios
-    expect(find_field('auto_name__33', checked: true, visible: false).value).to eq '3'
+    expect(find_field('auto_name__35', checked: true, visible: false).value).to eq '3'
 
     # select
-    expect(page).to have_select 'page_fieldset-third--fieldset--select_auto_name_34', selected: 'Three'
+    expect(page).to have_select 'page_fieldset-third--fieldset--select_auto_name_36', selected: 'Three'
 
     # text
-    expect(find_field('page_fieldset-third--fieldset--text_auto_name_35').value).to eq 'Three'
+    expect(find_field('page_fieldset-third--fieldset--text_auto_name_37').value).to eq 'Three'
 
     # textarea
-    expect(find_field('page_fieldset-third--fieldset--textarea_auto_name_36').value).to eq 'Three'
+    expect(find_field('page_fieldset-third--fieldset--textarea_auto_name_38').value).to eq 'Three'
 
     back
 
@@ -591,36 +591,36 @@ describe 'Fieldset' do
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Second - section heading'
 
     # autocomplete
-    # expect(find_field('page_fieldset-second--fieldset--autocomplete_auto_name_13').value).to eq 'Two'
+    expect(find_field('page_fieldset-second--fieldset--autocomplete_auto_name_14').value).to eq 'Two'
 
     # checkboxes
-    expect(page).to have_field('auto_name__14', visible: false, checked: false)
-    expect(page).to have_field('auto_name__15', visible: false, checked: true)
-    expect(page).to have_field('auto_name__16', visible: false, checked: false)
+    expect(page).to have_field('auto_name__15', visible: false, checked: false)
+    expect(page).to have_field('auto_name__16', visible: false, checked: true)
     expect(page).to have_field('auto_name__17', visible: false, checked: false)
+    expect(page).to have_field('auto_name__18', visible: false, checked: false)
 
     # date
-    expect(find_field('COMPOSITE--auto_name_18-day').value).to eq '2'
-    expect(find_field('COMPOSITE--auto_name_18-month').value).to eq '2'
-    expect(find_field('COMPOSITE--auto_name_18-year').value).to eq '1971'
+    expect(find_field('COMPOSITE--auto_name_19-day').value).to eq '2'
+    expect(find_field('COMPOSITE--auto_name_19-month').value).to eq '2'
+    expect(find_field('COMPOSITE--auto_name_19-year').value).to eq '1971'
 
     # email
-    expect(find_field('page_fieldset-second--fieldset--email_auto_name_19').value).to eq 'form-builder-developers@digital.justice.gov.uk'
+    expect(find_field('page_fieldset-second--fieldset--email_auto_name_20').value).to eq 'form-builder-developers@digital.justice.gov.uk'
 
     # number
-    expect(find_field('page_fieldset-second--fieldset--number_auto_name_20').value).to eq '2'
+    expect(find_field('page_fieldset-second--fieldset--number_auto_name_21').value).to eq '2'
 
     # radios
-    expect(find_field('auto_name__21', checked: true, visible: false).value).to eq '2'
+    expect(find_field('auto_name__22', checked: true, visible: false).value).to eq '2'
 
     # select
-    expect(page).to have_select 'page_fieldset-second--fieldset--select_auto_name_22', selected: 'Two'
+    expect(page).to have_select 'page_fieldset-second--fieldset--select_auto_name_23', selected: 'Two'
 
     # text
-    expect(find_field('page_fieldset-second--fieldset--text_auto_name_23').value).to eq 'Two'
+    expect(find_field('page_fieldset-second--fieldset--text_auto_name_24').value).to eq 'Two'
 
     # textarea
-    expect(find_field('page_fieldset-second--fieldset--textarea_auto_name_24').value).to eq 'Two'
+    expect(find_field('page_fieldset-second--fieldset--textarea_auto_name_25').value).to eq 'Two'
 
     back
 
@@ -628,7 +628,7 @@ describe 'Fieldset' do
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - First - section heading'
 
     # autocomplete
-    # expect(find_field('page_fieldset-first--fieldset--autocomplete_auto_name_1').value).to eq 'One'
+    expect(find_field('page_fieldset-first--fieldset--autocomplete_auto_name_1').value).to eq 'One'
 
     # checkboxes
     expect(page).to have_field('auto_name__2', visible: false, checked: true)
@@ -679,7 +679,7 @@ describe 'Fieldset' do
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - First - section heading'
 
     # autocomplete
-    # expect(find_field('page_fieldset-first--fieldset--autocomplete_auto_name_1').value).to eq 'One'
+    expect(find_field('page_fieldset-first--fieldset--autocomplete_auto_name_1').value).to eq 'One'
 
     # checkboxes
     expect(page).to have_field('auto_name__2', visible: false, checked: true)
@@ -725,39 +725,39 @@ describe 'Fieldset' do
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Second - section heading'
 
     # autocomplete
-    # expect(find_field('page_fieldset-second--fieldset--autocomplete_auto_name_13').value).to eq 'Two'
+    expect(find_field('page_fieldset-second--fieldset--autocomplete_auto_name_14').value).to eq 'Two'
 
     # checkboxes
-    expect(page).to have_field('auto_name__14', visible: false, checked: false)
-    expect(page).to have_field('auto_name__15', visible: false, checked: true)
-    expect(page).to have_field('auto_name__16', visible: false, checked: false)
+    expect(page).to have_field('auto_name__15', visible: false, checked: false)
+    expect(page).to have_field('auto_name__16', visible: false, checked: true)
     expect(page).to have_field('auto_name__17', visible: false, checked: false)
+    expect(page).to have_field('auto_name__18', visible: false, checked: false)
 
     # date
-    expect(find_field('COMPOSITE--auto_name_18-day').value).to eq '2'
-    expect(find_field('COMPOSITE--auto_name_18-month').value).to eq '2'
-    expect(find_field('COMPOSITE--auto_name_18-year').value).to eq '1971'
+    expect(find_field('COMPOSITE--auto_name_19-day').value).to eq '2'
+    expect(find_field('COMPOSITE--auto_name_19-month').value).to eq '2'
+    expect(find_field('COMPOSITE--auto_name_19-year').value).to eq '1971'
 
     # email
-    expect(find_field('page_fieldset-second--fieldset--email_auto_name_19').value).to eq 'form-builder-developers@digital.justice.gov.uk'
+    expect(find_field('page_fieldset-second--fieldset--email_auto_name_20').value).to eq 'form-builder-developers@digital.justice.gov.uk'
 
     # number
-    expect(find_field('page_fieldset-second--fieldset--number_auto_name_20').value).to eq '2'
+    expect(find_field('page_fieldset-second--fieldset--number_auto_name_21').value).to eq '2'
 
     # radios
-    expect(find_field('auto_name__21', checked: true, visible: false).value).to eq '2'
+    expect(find_field('auto_name__22', checked: true, visible: false).value).to eq '2'
 
     # select
-    expect(page).to have_select 'page_fieldset-second--fieldset--select_auto_name_22', selected: 'Two'
+    expect(page).to have_select 'page_fieldset-second--fieldset--select_auto_name_23', selected: 'Two'
 
     # text
-    expect(find_field('page_fieldset-second--fieldset--text_auto_name_23').value).to eq 'Two'
+    expect(find_field('page_fieldset-second--fieldset--text_auto_name_24').value).to eq 'Two'
 
     # textarea
-    expect(find_field('page_fieldset-second--fieldset--textarea_auto_name_24').value).to eq 'Two'
+    expect(find_field('page_fieldset-second--fieldset--textarea_auto_name_25').value).to eq 'Two'
 
     # upload
-    attach_file('auto_name__25[1]', 'spec/fixtures/files/2.jpg')
+    attach_file('auto_name__26[1]', 'spec/fixtures/files/2.jpg')
     continue
 
     expect(page).to have_selector 'h1', text: 'Fieldset - Second - Check'
@@ -771,39 +771,39 @@ describe 'Fieldset' do
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Third - section heading'
 
     # autocomplete
-    # expect(find_field('page_fieldset-third--fieldset--autocomplete_auto_name_25').value).to eq 'Three'
+    expect(find_field('page_fieldset-third--fieldset--autocomplete_auto_name_27').value).to eq 'Three'
 
     # checkboxes
-    expect(page).to have_field('auto_name__26', visible: false, checked: false)
-    expect(page).to have_field('auto_name__27', visible: false, checked: false)
-    expect(page).to have_field('auto_name__28', visible: false, checked: true)
+    expect(page).to have_field('auto_name__28', visible: false, checked: false)
     expect(page).to have_field('auto_name__29', visible: false, checked: false)
+    expect(page).to have_field('auto_name__30', visible: false, checked: true)
+    expect(page).to have_field('auto_name__31', visible: false, checked: false)
 
     # date
-    expect(find_field('COMPOSITE--auto_name_30-day').value).to eq '3'
-    expect(find_field('COMPOSITE--auto_name_30-month').value).to eq '3'
-    expect(find_field('COMPOSITE--auto_name_30-year').value).to eq '1972'
+    expect(find_field('COMPOSITE--auto_name_32-day').value).to eq '3'
+    expect(find_field('COMPOSITE--auto_name_32-month').value).to eq '3'
+    expect(find_field('COMPOSITE--auto_name_32-year').value).to eq '1972'
 
     # email
-    expect(find_field('page_fieldset-third--fieldset--email_auto_name_31').value).to eq 'form-builder-developers@digital.justice.gov.uk'
+    expect(find_field('page_fieldset-third--fieldset--email_auto_name_33').value).to eq 'form-builder-developers@digital.justice.gov.uk'
 
     # number
-    expect(find_field('page_fieldset-third--fieldset--number_auto_name_32').value).to eq '3'
+    expect(find_field('page_fieldset-third--fieldset--number_auto_name_34').value).to eq '3'
 
     # radios
-    expect(find_field('auto_name__33', checked: true, visible: false).value).to eq '3'
+    expect(find_field('auto_name__35', checked: true, visible: false).value).to eq '3'
 
     # select
-    expect(page).to have_select 'page_fieldset-third--fieldset--select_auto_name_34', selected: 'Three'
+    expect(page).to have_select 'page_fieldset-third--fieldset--select_auto_name_36', selected: 'Three'
 
     # text
-    expect(find_field('page_fieldset-third--fieldset--text_auto_name_35').value).to eq 'Three'
+    expect(find_field('page_fieldset-third--fieldset--text_auto_name_37').value).to eq 'Three'
 
     # textarea
-    expect(find_field('page_fieldset-third--fieldset--textarea_auto_name_36').value).to eq 'Three'
+    expect(find_field('page_fieldset-third--fieldset--textarea_auto_name_38').value).to eq 'Three'
 
     # upload
-    attach_file('auto_name__37[1]', 'spec/fixtures/files/3.jpg')
+    attach_file('auto_name__39[1]', 'spec/fixtures/files/3.jpg')
     continue
 
     expect(page).to have_selector 'h1', text: 'Fieldset - Third - Check'
@@ -817,39 +817,39 @@ describe 'Fieldset' do
     expect(page).to have_selector '.fb-sectionHeading', text: 'Fieldset - Fourth - section heading'
 
     # autocomplete
-    # expect(find_field('page_fieldset-fourth--fieldset--autocomplete_auto_name_37').value).to eq 'One'
+    expect(find_field('page_fieldset-fourth--fieldset--autocomplete_auto_name_40').value).to eq 'One'
 
     # checkboxes
-    expect(page).to have_field('auto_name__38', visible: false, checked: true)
-    expect(page).to have_field('auto_name__39', visible: false, checked: true)
-    expect(page).to have_field('auto_name__40', visible: false, checked: true)
     expect(page).to have_field('auto_name__41', visible: false, checked: true)
+    expect(page).to have_field('auto_name__42', visible: false, checked: true)
+    expect(page).to have_field('auto_name__43', visible: false, checked: true)
+    expect(page).to have_field('auto_name__44', visible: false, checked: true)
 
     # date
-    expect(find_field('COMPOSITE--auto_name_42-day').value).to eq '1'
-    expect(find_field('COMPOSITE--auto_name_42-month').value).to eq '1'
-    expect(find_field('COMPOSITE--auto_name_42-year').value).to eq '1970'
+    expect(find_field('COMPOSITE--auto_name_45-day').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_45-month').value).to eq '1'
+    expect(find_field('COMPOSITE--auto_name_45-year').value).to eq '1970'
 
     # email
-    expect(find_field('page_fieldset-fourth--fieldset--email_auto_name_43').value).to eq 'form-builder-team@digital.justice.gov.uk'
+    expect(find_field('page_fieldset-fourth--fieldset--email_auto_name_46').value).to eq 'form-builder-team@digital.justice.gov.uk'
 
     # number
-    expect(find_field('page_fieldset-fourth--fieldset--number_auto_name_44').value).to eq '1'
+    expect(find_field('page_fieldset-fourth--fieldset--number_auto_name_47').value).to eq '1'
 
     # radios
-    expect(find_field('auto_name__45', checked: true, visible: false).value).to eq '1'
+    expect(find_field('auto_name__48', checked: true, visible: false).value).to eq '1'
 
     # select
-    expect(page).to have_select 'page_fieldset-fourth--fieldset--select_auto_name_46', selected: 'One'
+    expect(page).to have_select 'page_fieldset-fourth--fieldset--select_auto_name_49', selected: 'One'
 
     # text
-    expect(find_field('page_fieldset-fourth--fieldset--text_auto_name_47').value).to eq 'One'
+    expect(find_field('page_fieldset-fourth--fieldset--text_auto_name_50').value).to eq 'One'
 
     # textarea
-    expect(find_field('page_fieldset-fourth--fieldset--textarea_auto_name_48').value).to eq 'One'
+    expect(find_field('page_fieldset-fourth--fieldset--textarea_auto_name_51').value).to eq 'One'
 
     # upload
-    attach_file('auto_name__49[1]', 'spec/fixtures/files/4.jpg')
+    attach_file('auto_name__52[1]', 'spec/fixtures/files/4.jpg')
     continue
 
     expect(page).to have_selector 'h1', text: 'Fieldset - Fourth - Check'
@@ -871,8 +871,8 @@ describe 'Fieldset' do
 
     expect(page).to have_selector 'h2:nth-of-type(1)', text: 'Fieldset - First - section heading'
 
-    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__key', text: 'Autocomplete'
-    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__value', text: 'One'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__key', text: 'Autocomplete'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__value', text: 'One'
 
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__key', text: 'Checkboxes'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__value', text: 'One'
@@ -903,8 +903,8 @@ describe 'Fieldset' do
 
     expect(page).to have_selector 'h2:nth-of-type(2)', text: 'Fieldset - Second - section heading'
 
-    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__key', text: 'Autocomplete'
-    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__value', text: 'Two'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__key', text: 'Autocomplete'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__value', text: 'Two'
 
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__key', text: 'Checkboxes'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__value', text: 'Two'
@@ -935,8 +935,8 @@ describe 'Fieldset' do
 
     expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Fieldset - Third - section heading'
 
-    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__key', text: 'Autocomplete'
-    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__value', text: 'Three'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__key', text: 'Autocomplete'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__value', text: 'Three'
 
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__key', text: 'Checkboxes'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__value', text: 'Three - summary version'
@@ -967,8 +967,8 @@ describe 'Fieldset' do
 
     expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Fieldset - Fourth - section heading'
 
-    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__key', text: 'Autocomplete'
-    # expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__value', text: 'One'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__key', text: 'Autocomplete'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__value', text: 'One'
 
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__key', text: 'Checkboxes'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__value', text: /One - summary version\s*Two - summary version\s*Three - summary version\s*Four - summary version/

--- a/tests/spec/number_spec.rb
+++ b/tests/spec/number_spec.rb
@@ -30,6 +30,12 @@ describe 'Number' do
     fill_in 'number-third', with: "3"
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Number - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
@@ -63,6 +69,12 @@ describe 'Number' do
     fill_in 'number-third', with: "1"
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Number - Third - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Number - Third'
@@ -75,36 +87,101 @@ describe 'Number' do
     ########################################
 
     # back
-    find('.govuk-back-link').click
+    back
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Number - Third - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Number - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Number - Third - hint text'
+
+    expect(find_field('number-third').value).to eq '1'
+    back
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Number - Second - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Number - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Number - Second - hint text'
+
+    expect(find_field('page_number-second--number_auto_name_2').value).to eq '2'
+    back
 
     # first
     expect(page).to have_selector '.fb-sectionHeading', text: 'Number - First - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Number - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Number - First - hint text'
+
+    expect(find_field('page_number-first--number_auto_name_1').value).to eq '1'
+    back
+
+    ########################################
+    #                                      #
+    #   START                              #
+    #                                      #
+    ########################################
+
+    # start
+    click_on 'Start'
+
+    ########################################
+    #                                      #
+    #   FORWARD                            #
+    #                                      #
+    ########################################
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Number - First - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Number - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Number - First - hint text'
+
+    expect(find_field('page_number-first--number_auto_name_1').value).to eq '1'
     continue
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Number - Second - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Number - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Number - Second - hint text'
+
+    expect(find_field('page_number-second--number_auto_name_2').value).to eq '2'
     continue
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Number - Third - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Number - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Number - Third - hint text'
+
+    expect(find_field('number-third').value).to eq '1'
     continue
+
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
 
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Number - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
 
+    expect(page).to have_selector 'h2:nth-of-type(1)', text: 'Number - First - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__key', text: 'Number - First'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__value', text: '1'
+
+    expect(page).to have_selector 'h2:nth-of-type(2)', text: 'Number - Second - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__key', text: 'Number - Second'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__value', text: '2'
+
+    expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Number - Third - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Number - Third'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: '1'
+
     click_on 'Accept and send application'
 
     # confirmation
     expect(page).to have_selector 'h1.govuk-panel__title', text: 'Number - Confirmation'
+  end
+
+  def back
+    find('.govuk-back-link').click
   end
 
   def continue

--- a/tests/spec/number_spec.rb
+++ b/tests/spec/number_spec.rb
@@ -46,7 +46,13 @@ describe 'Number' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Number - Third'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: '3'
 
-    # Change
+    ########################################
+    #                                      #
+    #   CHANGE                             #
+    #                                      #
+    ########################################
+
+    # change
     find('.govuk-summary-list:nth-of-type(3) .govuk-summary-list__actions a').click
 
     # number
@@ -61,6 +67,39 @@ describe 'Number' do
     expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Number - Third - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Number - Third'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: '1'
+
+    ########################################
+    #                                      #
+    #   BACK                               #
+    #                                      #
+    ########################################
+
+    # back
+    find('.govuk-back-link').click
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Number - Third - section heading'
+    find('.govuk-back-link').click
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Number - Second - section heading'
+    find('.govuk-back-link').click
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Number - First - section heading'
+    continue
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Number - Second - section heading'
+    continue
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Number - Third - section heading'
+    continue
+
+    # summary
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Number - Summary - section heading'
+    expect(page).to have_selector 'h1', text: 'Summary'
 
     click_on 'Accept and send application'
 

--- a/tests/spec/radios_spec.rb
+++ b/tests/spec/radios_spec.rb
@@ -58,7 +58,13 @@ describe 'Radios' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Radios - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'Four - summary version'
 
-    # Change
+    ########################################
+    #                                      #
+    #   CHANGE                             #
+    #                                      #
+    ########################################
+
+    # change
     find('.govuk-summary-list:nth-of-type(4) .govuk-summary-list__actions a').click
 
     # radios
@@ -73,6 +79,47 @@ describe 'Radios' do
     expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Radios - Fourth - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Radios - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'One - summary version'
+
+    ########################################
+    #                                      #
+    #   BACK                               #
+    #                                      #
+    ########################################
+
+    # back
+    find('.govuk-back-link').click
+
+    # fourth
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Fourth - section heading'
+    find('.govuk-back-link').click
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Third - section heading'
+    find('.govuk-back-link').click
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Second - section heading'
+    find('.govuk-back-link').click
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - First - section heading'
+    continue
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Second - section heading'
+    continue
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Third - section heading'
+    continue
+
+    # fourth
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Fourth - section heading'
+    continue
+
+    # summary
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Summary - section heading'
+    expect(page).to have_selector 'h1', text: 'Summary'
 
     click_on 'Accept and send application'
 

--- a/tests/spec/radios_spec.rb
+++ b/tests/spec/radios_spec.rb
@@ -38,6 +38,12 @@ describe 'Radios' do
     choose 'radios-four', option: '4', visible: false
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
@@ -75,6 +81,12 @@ describe 'Radios' do
     choose 'radios-four', option: '1', visible: false
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Radios - Fourth - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Radios - Fourth'
@@ -87,44 +99,121 @@ describe 'Radios' do
     ########################################
 
     # back
-    find('.govuk-back-link').click
+    back
 
     # fourth
     expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Fourth - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1', text: 'Radios - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Radios - Fourth - hint text'
+
+    expect(find_field('radios-four', checked: true, visible: false).value).to eq '1'
+    back
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Third - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1', text: 'Radios - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Radios - Third - hint text'
+
+    expect(find_field('auto_name__3', checked: true, visible: false).value).to eq '3'
+    back
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Second - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1', text: 'Radios - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Radios - Second - hint text'
+
+    expect(find_field('auto_name__2', checked: true, visible: false).value).to eq '2'
+    back
 
     # first
     expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - First - section heading'
+    expect(page).to have_selector 'h1', text: 'Radios - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Radios - First - hint text'
+
+    expect(find_field('auto_name__1', checked: true, visible: false).value).to eq '1'
+    back
+
+    ########################################
+    #                                      #
+    #   START                              #
+    #                                      #
+    ########################################
+
+    # start
+    click_on 'Start'
+
+    ########################################
+    #                                      #
+    #   FORWARD                            #
+    #                                      #
+    ########################################
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - First - section heading'
+    expect(page).to have_selector 'h1', text: 'Radios - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Radios - First - hint text'
+
+    expect(find_field('auto_name__1', checked: true, visible: false).value).to eq '1'
     continue
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Second - section heading'
+    expect(page).to have_selector 'h1', text: 'Radios - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Radios - Second - hint text'
+
+    expect(find_field('auto_name__2', checked: true, visible: false).value).to eq '2'
     continue
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Third - section heading'
+    expect(page).to have_selector 'h1', text: 'Radios - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Radios - Third - hint text'
+
+    expect(find_field('auto_name__3', checked: true, visible: false).value).to eq '3'
     continue
 
     # fourth
     expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Fourth - section heading'
+    expect(page).to have_selector 'h1', text: 'Radios - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Radios - Fourth - hint text'
+
+    expect(find_field('radios-four', checked: true, visible: false).value).to eq '1'
     continue
+
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
 
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Radios - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
 
+    expect(page).to have_selector 'h2:nth-of-type(1)', text: 'Radios - First - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__key', text: 'Radios - First'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector 'h2:nth-of-type(2)', text: 'Radios - Second - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__key', text: 'Radios - Second'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__value', text: 'Two'
+
+    expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Radios - Third - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Radios - Third'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'Three - summary version'
+
+    expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Radios - Fourth - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Radios - Fourth'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'One - summary version'
+
     click_on 'Accept and send application'
 
     # confirmation
     expect(page).to have_selector 'h1.govuk-panel__title', text: 'Radios - Confirmation'
+  end
+
+  def back
+    find('.govuk-back-link').click
   end
 
   def continue

--- a/tests/spec/select_spec.rb
+++ b/tests/spec/select_spec.rb
@@ -58,7 +58,13 @@ describe 'Select' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Select - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'Four - summary version'
 
-    # Change
+    ########################################
+    #                                      #
+    #   CHANGE                             #
+    #                                      #
+    ########################################
+
+    # change
     find('.govuk-summary-list:nth-of-type(4) .govuk-summary-list__actions a').click
 
     # select
@@ -73,6 +79,47 @@ describe 'Select' do
     expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Select - Fourth - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Select - Fourth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'One - summary version'
+
+    ########################################
+    #                                      #
+    #   BACK                               #
+    #                                      #
+    ########################################
+
+    # back
+    find('.govuk-back-link').click
+
+    # fourth
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Fourth - section heading'
+    find('.govuk-back-link').click
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Third - section heading'
+    find('.govuk-back-link').click
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Second - section heading'
+    find('.govuk-back-link').click
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Select - First - section heading'
+    continue
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Second - section heading'
+    continue
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Third - section heading'
+    continue
+
+    # fourth
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Fourth - section heading'
+    continue
+
+    # summary
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Summary - section heading'
+    expect(page).to have_selector 'h1', text: 'Summary'
 
     click_on 'Accept and send application'
 

--- a/tests/spec/select_spec.rb
+++ b/tests/spec/select_spec.rb
@@ -38,6 +38,12 @@ describe 'Select' do
     select 'Four', from: 'page_select-fourth--select_auto_name_4'
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
@@ -75,6 +81,12 @@ describe 'Select' do
     select 'One', from: 'page_select-fourth--select_auto_name_4'
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Select - Fourth - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Select - Fourth'
@@ -87,44 +99,121 @@ describe 'Select' do
     ########################################
 
     # back
-    find('.govuk-back-link').click
+    back
 
     # fourth
     expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Fourth - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Select - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Select - Fourth - hint text'
+
+    expect(page).to have_select 'page_select-fourth--select_auto_name_4', selected: 'One'
+    back
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Third - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Select - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Select - Third - hint text'
+
+    expect(page).to have_select 'page_select-third--select_auto_name_3', selected: 'Three'
+    back
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Second - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Select - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Select - Second - hint text'
+
+    expect(page).to have_select 'page_select-second--select_auto_name_2', selected: 'Two'
+    back
 
     # first
     expect(page).to have_selector '.fb-sectionHeading', text: 'Select - First - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Select - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Select - First - hint text'
+
+    expect(page).to have_select 'page_select-first--select_auto_name_1', selected: 'One'
+    back
+
+    ########################################
+    #                                      #
+    #   START                              #
+    #                                      #
+    ########################################
+
+    # start
+    click_on 'Start'
+
+    ########################################
+    #                                      #
+    #   FORWARD                            #
+    #                                      #
+    ########################################
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Select - First - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Select - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Select - First - hint text'
+
+    expect(page).to have_select 'page_select-first--select_auto_name_1', selected: 'One'
     continue
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Second - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Select - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Select - Second - hint text'
+
+    expect(page).to have_select 'page_select-second--select_auto_name_2', selected: 'Two'
     continue
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Third - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Select - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Select - Third - hint text'
+
+    expect(page).to have_select 'page_select-third--select_auto_name_3', selected: 'Three'
     continue
 
     # fourth
     expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Fourth - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Select - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Select - Fourth - hint text'
+
+    expect(page).to have_select 'page_select-fourth--select_auto_name_4', selected: 'One'
     continue
+
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
 
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Select - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
 
+    expect(page).to have_selector 'h2:nth-of-type(1)', text: 'Select - First - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__key', text: 'Select - First'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector 'h2:nth-of-type(2)', text: 'Select - Second - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__key', text: 'Select - Second'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__value', text: 'Two'
+
+    expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Select - Third - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Select - Third'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'Three - summary version'
+
+    expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Select - Fourth - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Select - Fourth'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: 'One - summary version'
+
     click_on 'Accept and send application'
 
     # confirmation
     expect(page).to have_selector 'h1.govuk-panel__title', text: 'Select - Confirmation'
+  end
+
+  def back
+    find('.govuk-back-link').click
   end
 
   def continue

--- a/tests/spec/text_spec.rb
+++ b/tests/spec/text_spec.rb
@@ -30,6 +30,12 @@ describe 'Text' do
     fill_in 'text-third', with: "Three"
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Text - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
@@ -63,6 +69,12 @@ describe 'Text' do
     fill_in 'text-third', with: "One"
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Text - Third - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Text - Third'
@@ -75,36 +87,100 @@ describe 'Text' do
     ########################################
 
     # back
-    find('.govuk-back-link').click
+    back
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Text - Third - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Text - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Text - Third - hint text'
+
+    expect(find_field('text-third').value).to eq 'One'
+    back
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Text - Second - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Text - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Text - Second - hint text'
+
+    expect(find_field('page_text-second--text_auto_name_2').value).to eq 'Two'
+    back
 
     # first
     expect(page).to have_selector '.fb-sectionHeading', text: 'Text - First - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Text - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Text - First - hint text'
+
+    expect(find_field('page_text-first--text_auto_name_1').value).to eq 'One'
+    back
+
+    ########################################
+    #                                      #
+    #   START                              #
+    #                                      #
+    ########################################
+
+    click_on 'Start'
+
+    ########################################
+    #                                      #
+    #   FORWARD                            #
+    #                                      #
+    ########################################
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Text - First - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Text - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Text - First - hint text'
+
+    expect(find_field('page_text-first--text_auto_name_1').value).to eq 'One'
     continue
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Text - Second - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Text - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Text - Second - hint text'
+
+    expect(find_field('page_text-second--text_auto_name_2').value).to eq 'Two'
     continue
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Text - Third - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Text - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Text - Third - hint text'
+
+    expect(find_field('text-third').value).to eq 'One'
     continue
+
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
 
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Text - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
 
+    expect(page).to have_selector 'h2:nth-of-type(1)', text: 'Text - First - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__key', text: 'Text - First'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__value', text: 'One'
+
+    expect(page).to have_selector 'h2:nth-of-type(2)', text: 'Text - Second - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__key', text: 'Text - Second'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__value', text: 'Two'
+
+    expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Text - Third - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Text - Third'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'One'
+
     click_on 'Accept and send application'
 
     # confirmation
     expect(page).to have_selector 'h1.govuk-panel__title', text: 'Text - Confirmation'
+  end
+
+  def back
+    find('.govuk-back-link').click
   end
 
   def continue

--- a/tests/spec/text_spec.rb
+++ b/tests/spec/text_spec.rb
@@ -46,7 +46,13 @@ describe 'Text' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Text - Third'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'Three'
 
-    # Change
+    ########################################
+    #                                      #
+    #   CHANGE                             #
+    #                                      #
+    ########################################
+
+    # change
     find('.govuk-summary-list:nth-of-type(3) .govuk-summary-list__actions a').click
 
     # text
@@ -61,6 +67,39 @@ describe 'Text' do
     expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Text - Third - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Text - Third'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'One'
+
+    ########################################
+    #                                      #
+    #   BACK                               #
+    #                                      #
+    ########################################
+
+    # back
+    find('.govuk-back-link').click
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Text - Third - section heading'
+    find('.govuk-back-link').click
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Text - Second - section heading'
+    find('.govuk-back-link').click
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Text - First - section heading'
+    continue
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Text - Second - section heading'
+    continue
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Text - Third - section heading'
+    continue
+
+    # summary
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Text - Summary - section heading'
+    expect(page).to have_selector 'h1', text: 'Summary'
 
     click_on 'Accept and send application'
 

--- a/tests/spec/textarea_spec.rb
+++ b/tests/spec/textarea_spec.rb
@@ -46,7 +46,13 @@ describe 'Textarea' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Textarea - Third'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'Three'
 
-    # Change
+    ########################################
+    #                                      #
+    #   CHANGE                             #
+    #                                      #
+    ########################################
+
+    # change
     find('.govuk-summary-list:nth-of-type(3) .govuk-summary-list__actions a').click
 
     # textarea
@@ -61,6 +67,39 @@ describe 'Textarea' do
     expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Textarea - Third - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Textarea - Third'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: 'One'
+
+    ########################################
+    #                                      #
+    #   BACK                               #
+    #                                      #
+    ########################################
+
+    # back
+    find('.govuk-back-link').click
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Textarea - Third - section heading'
+    find('.govuk-back-link').click
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Textarea - Second - section heading'
+    find('.govuk-back-link').click
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Textarea - First - section heading'
+    continue
+
+    # second
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Textarea - Second - section heading'
+    continue
+
+    # third
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Textarea - Third - section heading'
+    continue
+
+    # summary
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Textarea - Summary - section heading'
+    expect(page).to have_selector 'h1', text: 'Summary'
 
     click_on 'Accept and send application'
 

--- a/tests/spec/textarea_spec.rb
+++ b/tests/spec/textarea_spec.rb
@@ -30,6 +30,12 @@ describe 'Textarea' do
     fill_in 'textarea-third', with: "Three"
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Textarea - Summary - section heading'
     expect(page).to have_selector 'h1', text: 'Summary'
@@ -63,6 +69,12 @@ describe 'Textarea' do
     fill_in 'textarea-third', with: "One"
     continue
 
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
     # summary
     expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Textarea - Third - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Textarea - Third'
@@ -75,27 +87,75 @@ describe 'Textarea' do
     ########################################
 
     # back
-    find('.govuk-back-link').click
+    back
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Textarea - Third - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Textarea - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Textarea - Third - hint text'
+
+    expect(find_field('textarea-third').value).to eq 'One'
+    back
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Textarea - Second - section heading'
-    find('.govuk-back-link').click
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Textarea - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Textarea - Second - hint text'
+
+    expect(find_field('page_textarea-second--textarea_auto_name_2').value).to eq 'Two'
+    back
 
     # first
     expect(page).to have_selector '.fb-sectionHeading', text: 'Textarea - First - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Textarea - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Textarea - First - hint text'
+
+    expect(find_field('page_textarea-first--textarea_auto_name_1').value).to eq 'One'
+    back
+
+    ########################################
+    #                                      #
+    #   START                              #
+    #                                      #
+    ########################################
+
+    click_on 'Start'
+
+    ########################################
+    #                                      #
+    #   FORWARD                            #
+    #                                      #
+    ########################################
+
+    # first
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Textarea - First - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Textarea - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Textarea - First - hint text'
+
+    expect(find_field('page_textarea-first--textarea_auto_name_1').value).to eq 'One'
     continue
 
     # second
     expect(page).to have_selector '.fb-sectionHeading', text: 'Textarea - Second - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Textarea - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Textarea - Second - hint text'
+
+    expect(find_field('page_textarea-second--textarea_auto_name_2').value).to eq 'Two'
     continue
 
     # third
     expect(page).to have_selector '.fb-sectionHeading', text: 'Textarea - Third - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Textarea - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Textarea - Third - hint text'
+
+    expect(find_field('textarea-third').value).to eq 'One'
     continue
+
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
 
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Textarea - Summary - section heading'
@@ -105,6 +165,10 @@ describe 'Textarea' do
 
     # confirmation
     expect(page).to have_selector 'h1.govuk-panel__title', text: 'Textarea - Confirmation'
+  end
+
+  def back
+    find('.govuk-back-link').click
   end
 
   def continue

--- a/tests/spec/upload_spec.rb
+++ b/tests/spec/upload_spec.rb
@@ -111,8 +111,7 @@ describe 'Upload' do
     expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__key', text: 'Upload - Fourth'
     expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__value', text: '3.jpg, 1.34MB'
 
-    # MAX FILES, NO CONFIRM
-    continue
+    continue # MAX FILE - NO CONFIRM
 
     # upload
     expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Fifth - section heading'
@@ -170,8 +169,7 @@ describe 'Upload' do
     expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__key', text: 'Upload - Fifth'
     expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__value', text: '3.jpg, 1.34MB'
 
-    # MAX FILES, NO CONFIRM
-    continue
+    continue # MAX FILE - NO CONFIRM
 
     # upload
     expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Sixth - section heading'
@@ -229,8 +227,13 @@ describe 'Upload' do
     expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__key', text: 'Upload - Sixth'
     expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__value', text: '3.jpg, 1.34MB'
 
-    # MAX FILES, NO CONFIRM
-    continue
+    continue # MAX FILE - NO CONFIRM
+
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
 
     # summary
     expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Summary - section heading'
@@ -260,6 +263,12 @@ describe 'Upload' do
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(6) .govuk-summary-list__key', text: 'Upload - Sixth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(6) .govuk-summary-list__value', text: /1\.jpg \(1\.34MB\)\s*2\.jpg \(1\.34MB\)\s*3\.jpg \(1\.34MB\)/
 
+    ########################################
+    #                                      #
+    #   CHANGE                             #
+    #                                      #
+    ########################################
+
     # Change
     find('.govuk-summary-list:nth-of-type(6) .govuk-summary-list__actions a').click
 
@@ -278,17 +287,219 @@ describe 'Upload' do
     expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__key', text: 'Upload - Sixth'
     expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__value', text: '4.jpg, 1.34MB'
 
-    # MAX FILES, NO CONFIRM
-    continue
+    continue # MAX FILE - NO CONFIRM
+
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
 
     expect(page).to have_selector 'h2:nth-of-type(6)', text: 'Upload - Sixth - section heading'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(6) .govuk-summary-list__key', text: 'Upload - Sixth'
     expect(page).to have_selector '.govuk-summary-list:nth-of-type(6) .govuk-summary-list__value', text: /1\.jpg \(1\.34MB\)\s*2\.jpg \(1\.34MB\)\s*4\.jpg \(1\.34MB\)/
 
+    ########################################
+    #                                      #
+    #   BACK                               #
+    #                                      #
+    ########################################
+
+    # back
+    back
+
+    # upload
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Sixth - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Upload - Sixth'
+    expect(page).to have_selector '.govuk-hint', text: 'Upload - Sixth - hint text'
+    back
+
+    # upload
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Fifth - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Upload - Fifth'
+    expect(page).to have_selector '.govuk-hint', text: 'Upload - Fifth - hint text'
+    back
+
+    # upload
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Fourth - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Upload - Fourth'
+    expect(page).to have_selector '.govuk-hint', text: 'Upload - Fourth - hint text'
+    back
+
+    # upload
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Third - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Upload - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Upload - Third - hint text'
+    back
+
+    # upload
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Second - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Upload - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Upload - Second - hint text'
+    back
+
+    # upload
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - First - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Upload - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Upload - First - hint text'
+    back
+
+    ########################################
+    #                                      #
+    #   START                              #
+    #                                      #
+    ########################################
+
+    click_on 'Start'
+
+    ########################################
+    #                                      #
+    #   FORWARD                            #
+    #                                      #
+    ########################################
+
+    # upload
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - First - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Upload - First'
+    expect(page).to have_selector '.govuk-hint', text: 'Upload - First - hint text'
+
+    # upload
+    attach_file('auto_name__1[1]', 'spec/fixtures/files/1.jpg')
+    continue
+
+    expect(page).to have_selector 'h1', text: 'Upload - First - Check'
+    expect(page).to have_selector '.fb-upload-descriptions', text: '1.jpg, 1.34MB'
+
+    # radios
+    choose 'decision', option: 'accept', visible: false
+    continue
+
+    # upload
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Second - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Upload - Second'
+    expect(page).to have_selector '.govuk-hint', text: 'Upload - Second - hint text'
+
+    attach_file('auto_name__2[1]', 'spec/fixtures/files/2.jpg')
+    continue
+
+    # check
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Second - section heading'
+    expect(page).to have_selector 'h1', text: 'Upload - Second - Check'
+    expect(page).to have_selector '.fb-upload-descriptions', text: '2.jpg, 1.34MB'
+
+    # radios
+    choose 'decision', option: 'accept', visible: false
+    continue
+
+    # upload
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Third - section heading'
+    expect(page).to have_selector 'h1 label.govuk-label', text: 'Upload - Third'
+    expect(page).to have_selector '.govuk-hint', text: 'Upload - Third - hint text'
+
+    attach_file('upload-third[1]', 'spec/fixtures/files/3.jpg')
+    continue
+
+    # check
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Third - section heading'
+    expect(page).to have_selector 'h1', text: 'Upload - Third - Check'
+    expect(page).to have_selector '.fb-upload-descriptions', text: '3.jpg, 1.34MB'
+
+    choose 'decision', option: 'accept', visible: false
+    continue
+
+    # upload
+    attach_file('auto_name__4[3]', 'spec/fixtures/files/1.jpg')
+    continue
+
+    expect(page).to have_selector 'h1', text: 'Upload - Fourth - Check'
+    expect(page).to have_selector '.fb-upload-descriptions', text: '1.jpg, 1.34MB'
+
+    choose 'decision', option: 'accept', visible: false
+    continue
+
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Fourth - section heading'
+    expect(page).to have_selector 'h1', text: 'Upload - Fourth - Summary'
+    expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__key', text: 'Upload - Fourth'
+    expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__value', text: '1.jpg, 1.34MB'
+
+    continue # MAX FILE - NO CONFIRM
+
+    # upload
+    attach_file('auto_name__5[3]', 'spec/fixtures/files/2.jpg')
+    continue
+
+    expect(page).to have_selector 'h1', text: 'Upload - Fifth - Check'
+    expect(page).to have_selector '.fb-upload-descriptions', text: '2.jpg, 1.34MB'
+
+    choose 'decision', option: 'accept', visible: false
+    continue
+
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Fifth - section heading'
+    expect(page).to have_selector 'h1', text: 'Upload - Fifth - Summary'
+    expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__key', text: 'Upload - Fifth'
+    expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__value', text: '2.jpg, 1.34MB'
+
+    continue # MAX FILE - NO CONFIRM
+
+    # upload
+    attach_file('upload-sixth[3]', 'spec/fixtures/files/3.jpg')
+    continue
+
+    expect(page).to have_selector 'h1', text: 'Upload - Sixth - Check'
+    expect(page).to have_selector '.fb-upload-descriptions', text: '3.jpg, 1.34MB'
+
+    choose 'decision', option: 'accept', visible: false
+    continue
+
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Sixth - section heading'
+    expect(page).to have_selector 'h1', text: 'Upload - Sixth - Summary'
+    expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__key', text: 'Upload - Sixth'
+    expect(page).to have_selector '.govuk-summary-list .govuk-summary-list__row:nth-of-type(3) .govuk-summary-list__value', text: '3.jpg, 1.34MB'
+
+    continue # MAX FILE - NO CONFIRM
+
+    ########################################
+    #                                      #
+    #   SUMMARY                            #
+    #                                      #
+    ########################################
+
+    # summary
+    expect(page).to have_selector '.fb-sectionHeading', text: 'Upload - Summary - section heading'
+    expect(page).to have_selector 'h1', text: 'Summary'
+
+    expect(page).to have_selector 'h2:nth-of-type(1)', text: 'Upload - First - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__key', text: 'Upload - First'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(1) .govuk-summary-list__value', text: '1.jpg (1.34MB)'
+
+    expect(page).to have_selector 'h2:nth-of-type(2)', text: 'Upload - Second - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__key', text: 'Upload - Second'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(2) .govuk-summary-list__value', text: '2.jpg (1.34MB)'
+
+    expect(page).to have_selector 'h2:nth-of-type(3)', text: 'Upload - Third - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__key', text: 'Upload - Third'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(3) .govuk-summary-list__value', text: '3.jpg (1.34MB)'
+
+    expect(page).to have_selector 'h2:nth-of-type(4)', text: 'Upload - Fourth - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__key', text: 'Upload - Fourth'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(4) .govuk-summary-list__value', text: /1\.jpg \(1\.34MB\)\s*2\.jpg \(1\.34MB\)\s*1\.jpg \(1\.34MB\)/
+
+    expect(page).to have_selector 'h2:nth-of-type(5)', text: 'Upload - Fifth - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(5) .govuk-summary-list__key', text: 'Upload - Fifth'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(5) .govuk-summary-list__value', text: /1\.jpg \(1\.34MB\)\s*2\.jpg \(1\.34MB\)\s*2\.jpg \(1\.34MB\)/
+
+    expect(page).to have_selector 'h2:nth-of-type(6)', text: 'Upload - Sixth - section heading'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(6) .govuk-summary-list__key', text: 'Upload - Sixth'
+    expect(page).to have_selector '.govuk-summary-list:nth-of-type(6) .govuk-summary-list__value', text: /1\.jpg \(1\.34MB\)\s*2\.jpg \(1\.34MB\)\s*3\.jpg \(1\.34MB\)/
+
     click_on 'Accept and send application'
 
     # confirmation
     expect(page).to have_selector 'h1.govuk-panel__title', text: 'Upload - Confirmation'
+  end
+
+  def back
+    find('.govuk-back-link').click
   end
 
   def continue


### PR DESCRIPTION
- Suite now progresses through component Forms, then navigates back, then navigates forward again, asserting page values

This suite is getting to be quite comprehensive but it could do with some structure

I'll address the issues of structure in another story/bug. For now it will do at least to have coverage

(This bug fix has identified another bug through the creation of these acceptance tests)